### PR TITLE
Improve QR code logo placement with better aspect ratio handling

### DIFF
--- a/app/Http/Controllers/OrtsverbandInvitationController.php
+++ b/app/Http/Controllers/OrtsverbandInvitationController.php
@@ -202,25 +202,40 @@ class OrtsverbandInvitationController extends Controller
         $logoWidth = imagesx($logo);
         $logoHeight = imagesy($logo);
 
-        // Logo-Größe (20% des QR-Codes)
-        $logoTargetWidth = $qrWidth * 0.20;
-        $logoTargetHeight = $logoHeight * ($logoTargetWidth / $logoWidth);
-
-        // Position (zentriert)
-        $logoX = ($qrWidth - $logoTargetWidth) / 2;
-        $logoY = ($qrHeight - $logoTargetHeight) / 2;
-
-        // Weißer Hintergrund für Logo (Aussparung)
-        $white = imagecolorallocate($qrImage, 255, 255, 255);
+        // Quadratische Aussparung (20% des QR-Codes)
+        $cutoutSize = $qrWidth * 0.20;
         $padding = 15;
+
+        // Position der quadratischen Aussparung (zentriert)
+        $cutoutX = ($qrWidth - $cutoutSize) / 2;
+        $cutoutY = ($qrHeight - $cutoutSize) / 2;
+
+        // Weißer Hintergrund für Logo (quadratische Aussparung)
+        $white = imagecolorallocate($qrImage, 255, 255, 255);
         imagefilledrectangle(
             $qrImage,
-            $logoX - $padding,
-            $logoY - $padding,
-            $logoX + $logoTargetWidth + $padding,
-            $logoY + $logoTargetHeight + $padding,
+            $cutoutX - $padding,
+            $cutoutY - $padding,
+            $cutoutX + $cutoutSize + $padding,
+            $cutoutY + $cutoutSize + $padding,
             $white
         );
+
+        // Logo proportional in die quadratische Fläche einpassen
+        $logoRatio = $logoWidth / $logoHeight;
+        if ($logoRatio > 1) {
+            // Logo ist breiter als hoch
+            $logoTargetWidth = $cutoutSize;
+            $logoTargetHeight = $cutoutSize / $logoRatio;
+        } else {
+            // Logo ist höher als breit
+            $logoTargetHeight = $cutoutSize;
+            $logoTargetWidth = $cutoutSize * $logoRatio;
+        }
+
+        // Logo zentriert in der quadratischen Aussparung platzieren
+        $logoX = $cutoutX + ($cutoutSize - $logoTargetWidth) / 2;
+        $logoY = $cutoutY + ($cutoutSize - $logoTargetHeight) / 2;
 
         // Logo einfügen
         imagecopyresampled(


### PR DESCRIPTION
## Summary
Enhanced the QR code logo overlay logic to properly handle logos with different aspect ratios. The logo is now intelligently scaled to fit within a square cutout while maintaining its original proportions and centered alignment.

## Key Changes
- Refactored logo sizing logic to use a square cutout area instead of stretching the logo to fixed dimensions
- Added aspect ratio detection to scale logos proportionally:
  - Wider logos (landscape) are scaled to the full cutout width
  - Taller logos (portrait) are scaled to the full cutout height
- Improved variable naming for clarity (`logoTargetWidth/Height` → `cutoutSize`, `logoX/Y` → `cutoutX/Y`)
- Ensured logos are centered both within the square cutout and within the white background padding

## Implementation Details
- The cutout size remains 20% of the QR code dimensions with 15px padding
- Logo aspect ratio is calculated and used to determine the optimal scaling direction
- Final logo positioning accounts for both the cutout offset and internal centering within the square area
- This prevents logo distortion while maintaining a clean, centered appearance in the QR code

https://claude.ai/code/session_018S89A6vNxaiZRowTJYmisr