### PR TITLE
Fix spaced repetition by removing questions from session instead of re-queuing

### DIFF
--- a/app/Http/Controllers/PracticeController.php
+++ b/app/Http/Controllers/PracticeController.php
@@ -583,20 +583,14 @@ class PracticeController extends Controller
             $gamificationService = new GamificationService();
             $gamificationResult = $gamificationService->awardQuestionPoints($user, $isCorrect, $question->id);
 
-            // Bei nicht-gemeisterter Antwort: Frage nicht aus der Session entfernen, sondern weiter hinten einreihen
+            // Frage aus der aktuellen Session entfernen - Spaced Repetition plant die Wiederholung
+            // WICHTIG: Frage NICHT ans Ende re-queuen, da sonst dieselbe Frage mehrfach in einer
+            // Session beantwortet wird und der SM-2 Algorithmus falsche Intervalle berechnet
             $practiceIds = session('practice_ids', []);
             if (!empty($practiceIds)) {
-                // Entferne aktuelle Frage und füge sie am Ende wieder hinzu
-                $currentIndex = array_search($question->id, $practiceIds);
-                if ($currentIndex !== false) {
-                    unset($practiceIds[$currentIndex]);
-                    $practiceIds[] = $question->id; // Am Ende hinzufügen
-                    session(['practice_ids' => array_values($practiceIds)]);
-                }
+                $practiceIds = array_diff($practiceIds, [$question->id]);
+                session(['practice_ids' => array_values($practiceIds)]);
             }
-
-            // NICHT zu skipped hinzufügen! Die Frage bleibt in practice_ids und kommt später wieder
-            // Sie wird nur durch answer_result temporär "pausiert" für diese Anzeige
         }
         
         // Immer Gamification Result in Session speichern


### PR DESCRIPTION
## Summary
This PR fixes the spaced repetition logic in the practice controller to properly remove answered questions from the current session instead of re-queuing them at the end. This ensures the SM-2 algorithm calculates correct review intervals without duplicate answers in a single session.

## Key Changes
- **Simplified question removal logic**: Replaced the manual array search and re-queue approach with `array_diff()` for cleaner code
- **Fixed SM-2 algorithm behavior**: Questions are now completely removed from the session after being answered, preventing them from being asked multiple times in the same session
- **Corrected spaced repetition flow**: The SM-2 algorithm now handles scheduling the next review independently, rather than the session logic trying to manage re-queuing
- **Removed misleading comments**: Deleted outdated comments about skipping and temporary pausing that no longer reflect the intended behavior

## Implementation Details
The key insight is that spaced repetition scheduling should be handled by the SM-2 algorithm (via `GamificationService`), not by the session queue management. By removing answered questions from `practice_ids` entirely, we ensure:
- Each question is answered only once per session
- The SM-2 algorithm receives accurate data for interval calculations
- Future review scheduling is based on correct performance history

https://claude.ai/code/session_01R41w2DcZyTjadNmPvpfwKR