### PR TITLE
Add source tracking to question statistics (exam vs practice)

### DIFF
--- a/app/Http/Controllers/ExamController.php
+++ b/app/Http/Controllers/ExamController.php
@@ -184,6 +184,7 @@ class ExamController extends Controller
                 'question_id' => $result['frage']->id,
                 'user_id' => $user->id,
                 'is_correct' => $result['isCorrect'],
+                'source' => 'exam',
             ]);
             
             // NEU: Auch Fortschritt in user_question_progress tracken
@@ -354,7 +355,7 @@ class ExamController extends Controller
             ->reverse()
             ->values();
 
-        // Analyse pro Lernabschnitt (basierend auf letzter Prüfung)
+        // Analyse pro Lernabschnitt (nur Prüfungsdaten)
         $sectionAnalysis = [];
         $latestExam = $exams->first();
         if ($latestExam) {
@@ -362,9 +363,11 @@ class ExamController extends Controller
                 $sectionQuestionIds = Question::where('lernabschnitt', $section)->pluck('id')->toArray();
                 $totalInSection = QuestionStatistic::where('user_id', $user->id)
                     ->whereIn('question_id', $sectionQuestionIds)
+                    ->where('source', 'exam')
                     ->count();
                 $correctInSection = QuestionStatistic::where('user_id', $user->id)
                     ->whereIn('question_id', $sectionQuestionIds)
+                    ->where('source', 'exam')
                     ->where('is_correct', true)
                     ->count();
 

--- a/app/Http/Controllers/GuestExamController.php
+++ b/app/Http/Controllers/GuestExamController.php
@@ -74,6 +74,7 @@ class GuestExamController extends Controller
             QuestionStatistic::create([
                 'question_id' => $frage->id,
                 'is_correct' => $isCorrect,
+                'source' => 'exam',
             ]);
         }
         

--- a/app/Http/Controllers/GuestPracticeController.php
+++ b/app/Http/Controllers/GuestPracticeController.php
@@ -161,6 +161,7 @@ class GuestPracticeController extends Controller
         QuestionStatistic::create([
             'question_id' => $question->id,
             'is_correct' => $isCorrect,
+            'source' => 'practice',
         ]);
 
         $skipped = session('guest_practice_skipped', []);

--- a/app/Http/Controllers/LandingGuestExamController.php
+++ b/app/Http/Controllers/LandingGuestExamController.php
@@ -78,6 +78,7 @@ class LandingGuestExamController extends Controller
             QuestionStatistic::create([
                 'question_id' => $frage->id,
                 'is_correct' => $isCorrect,
+                'source' => 'exam',
             ]);
         }
 

--- a/app/Http/Controllers/LandingGuestPracticeController.php
+++ b/app/Http/Controllers/LandingGuestPracticeController.php
@@ -151,6 +151,7 @@ class LandingGuestPracticeController extends Controller
         QuestionStatistic::create([
             'question_id' => $question->id,
             'is_correct' => $isCorrect,
+            'source' => 'practice',
         ]);
 
         $skipped = session('guest_practice_skipped', []);

--- a/app/Models/QuestionStatistic.php
+++ b/app/Models/QuestionStatistic.php
@@ -10,6 +10,7 @@ class QuestionStatistic extends Model
         'question_id',
         'user_id',
         'is_correct',
+        'source',
     ];
 
     protected $casts = [

--- a/database/migrations/2026_02_09_000001_add_source_to_question_statistics.php
+++ b/database/migrations/2026_02_09_000001_add_source_to_question_statistics.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('question_statistics', function (Blueprint $table) {
+            $table->string('source', 20)->nullable()->after('is_correct')
+                ->comment('exam or practice');
+            $table->index('source');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('question_statistics', function (Blueprint $table) {
+            $table->dropIndex(['source']);
+            $table->dropColumn('source');
+        });
+    }
+};

--- a/resources/views/exam-history.blade.php
+++ b/resources/views/exam-history.blade.php
@@ -360,7 +360,7 @@
         <!-- Lernabschnitt-Analyse -->
         @if(!empty($sectionAnalysis))
         <div class="section-header">
-            <h2 class="section-title">Stärken & Schwächen pro Abschnitt</h2>
+            <h2 class="section-title">Stärken & Schwächen pro Abschnitt (Prüfungen)</h2>
         </div>
 
         <div class="section-grid" style="margin-bottom: 2rem;">


### PR DESCRIPTION
## Summary
This PR adds a `source` field to the `QuestionStatistic` model to distinguish between questions answered during exams versus practice sessions. This enables more accurate analytics and reporting by filtering statistics based on the source of the answer.

## Key Changes
- **Database Migration**: Added `source` column (nullable string, max 20 chars) to `question_statistics` table with an index for query performance
- **Model Update**: Added `source` to the `$fillable` array in `QuestionStatistic` model
- **Exam Controllers**: Updated `ExamController`, `GuestExamController`, and `LandingGuestExamController` to set `source = 'exam'` when creating question statistics
- **Practice Controllers**: Updated `GuestPracticeController` and `LandingGuestPracticeController` to set `source = 'practice'` when creating question statistics
- **Analytics Filtering**: Modified `ExamController::history()` to filter section analysis by `source = 'exam'` only, ensuring exam history reports only reflect exam performance
- **UI Update**: Updated exam history view to clarify that section analysis ("Stärken & Schwächen pro Abschnitt") is based on exam data only

## Implementation Details
- The `source` field accepts values: `'exam'` or `'practice'`
- Field is nullable to maintain backward compatibility with existing records
- Index on `source` column improves query performance for filtered analytics
- Section analysis in exam history now explicitly filters for exam-sourced statistics, preventing practice attempts from skewing exam performance metrics

https://claude.ai/code/session_015JZumTZmfAeYZPjCAkUDih