### PR TITLE
Add exam-question relationship tracking with foreign keys

### DIFF
--- a/app/Models/ExamStatistic.php
+++ b/app/Models/ExamStatistic.php
@@ -21,4 +21,9 @@ class ExamStatistic extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function questionStatistics()
+    {
+        return $this->hasMany(QuestionStatistic::class);
+    }
 }

--- a/app/Models/QuestionStatistic.php
+++ b/app/Models/QuestionStatistic.php
@@ -11,6 +11,7 @@ class QuestionStatistic extends Model
         'user_id',
         'is_correct',
         'source',
+        'exam_statistic_id',
     ];
 
     protected $casts = [
@@ -31,6 +32,14 @@ class QuestionStatistic extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Eine Statistik gehört zu einer Prüfung (optional)
+     */
+    public function examStatistic(): BelongsTo
+    {
+        return $this->belongsTo(ExamStatistic::class);
     }
 }
 

--- a/database/migrations/2026_02_10_000002_add_exam_statistic_id_to_question_statistics.php
+++ b/database/migrations/2026_02_10_000002_add_exam_statistic_id_to_question_statistics.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('question_statistics', function (Blueprint $table) {
+            $table->foreignId('exam_statistic_id')->nullable()->after('source')
+                ->constrained('exam_statistics')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('question_statistics', function (Blueprint $table) {
+            $table->dropForeign(['exam_statistic_id']);
+            $table->dropColumn('exam_statistic_id');
+        });
+    }
+};

--- a/database/migrations/2026_02_10_000003_backfill_exam_statistic_id_in_question_statistics.php
+++ b/database/migrations/2026_02_10_000003_backfill_exam_statistic_id_in_question_statistics.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Backfill: Verknüpfe question_statistics mit exam_statistics.
+        // Für jede Prüfung finde die 40 question_statistics desselben Users
+        // die zeitlich am nächsten liegen (innerhalb ±60 Sekunden).
+        $examStats = DB::table('exam_statistics')
+            ->orderBy('created_at', 'asc')
+            ->get();
+
+        foreach ($examStats as $exam) {
+            $examTime = strtotime($exam->created_at);
+
+            // Finde question_statistics ohne exam_statistic_id innerhalb ±60 Sekunden
+            $questionIds = DB::table('question_statistics')
+                ->where('user_id', $exam->user_id)
+                ->whereNull('exam_statistic_id')
+                ->whereBetween('created_at', [
+                    date('Y-m-d H:i:s', $examTime - 60),
+                    date('Y-m-d H:i:s', $examTime + 60),
+                ])
+                ->orderBy('created_at', 'asc')
+                ->limit(40)
+                ->pluck('id')
+                ->toArray();
+
+            if (!empty($questionIds)) {
+                DB::table('question_statistics')
+                    ->whereIn('id', $questionIds)
+                    ->update([
+                        'exam_statistic_id' => $exam->id,
+                        'source' => 'exam',
+                    ]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        DB::table('question_statistics')
+            ->whereNotNull('exam_statistic_id')
+            ->update(['exam_statistic_id' => null]);
+    }
+};


### PR DESCRIPTION
## Summary
This PR establishes a proper relationship between exam submissions and individual question statistics by introducing a foreign key constraint. This allows tracking which questions were answered as part of which exam attempt, improving data integrity and enabling better analytics.

## Key Changes

- **Reordered exam submission logic**: `ExamStatistic` is now created before `QuestionStatistic` records so the exam ID is available for linking
- **Added foreign key relationship**: New `exam_statistic_id` column in `question_statistics` table with cascade delete
- **Updated model relationships**: 
  - `ExamStatistic` now has `hasMany` relationship to `QuestionStatistic`
  - `QuestionStatistic` now has `belongsTo` relationship to `ExamStatistic`
- **Migrated filtering logic**: Changed exam history queries from filtering by `source = 'exam'` to `whereNotNull('exam_statistic_id')` for more reliable identification
- **Data migration**: Added backfill migration to link existing question statistics to their corresponding exam statistics based on timestamp proximity (±60 seconds)

## Implementation Details

- The backfill migration intelligently matches question statistics to exams by finding the 40 most recent questions for each user within a 60-second window of the exam creation time
- The foreign key uses `onDelete('cascade')` to maintain referential integrity when exams are deleted
- The `exam_statistic_id` field is nullable to support non-exam question statistics (e.g., from practice mode)
- All existing exam-related queries now use the explicit relationship instead of relying on the `source` field

## Benefits

- Stronger data integrity through database constraints
- Clearer relationship between exams and their constituent questions
- Foundation for more detailed exam analytics and reporting
- Eliminates ambiguity in identifying exam-sourced statistics

https://claude.ai/code/session_015cyb7SZp9HcpA6QZX4THT4