### PR TITLE
Fix mastery threshold for solved questions in practice mode

### DIFF
--- a/app/Http/Controllers/PracticeController.php
+++ b/app/Http/Controllers/PracticeController.php
@@ -212,6 +212,10 @@ class PracticeController extends Controller
 
                 $toLearnIds = array_unique(array_merge($unmasteredIds, $neverAnsweredIds));
                 $toLearnIds = array_diff($toLearnIds, $alreadyQueued);
+                // Bereits gelöste Fragen gehören NICHT in den Lern-Pool
+                // (solved_questions kann Fragen enthalten deren consecutive_correct < MASTERY_THRESHOLD ist,
+                // z.B. durch Datenmigration - diese sollen trotzdem nicht als "zu lernen" gelten)
+                $toLearnIds = array_diff($toLearnIds, $solved);
 
                 // Nach Lernabschnitten sortiert, innerhalb zufällig
                 $sortedToLearnIds = [];

--- a/database/migrations/2026_02_10_000002_fix_solved_questions_mastery_threshold.php
+++ b/database/migrations/2026_02_10_000002_fix_solved_questions_mastery_threshold.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Korrigiert consecutive_correct für bereits gelöste Fragen.
+     *
+     * Die initiale Migration setzte consecutive_correct=2 für solved_questions,
+     * aber MASTERY_THRESHOLD wurde auf 3 erhöht. Dadurch wurden gelöste Fragen
+     * fälschlicherweise als "nicht gemeistert" eingestuft und im Practice-Modus
+     * vor wirklich ungelösten Fragen angezeigt.
+     */
+    public function up(): void
+    {
+        $users = DB::table('users')
+            ->whereNotNull('solved_questions')
+            ->get();
+
+        $updatedCount = 0;
+
+        foreach ($users as $user) {
+            $solved = json_decode($user->solved_questions, true) ?? [];
+
+            if (empty($solved)) {
+                continue;
+            }
+
+            // Setze consecutive_correct auf MASTERY_THRESHOLD (3) für gelöste Fragen,
+            // die noch unter dem Threshold liegen
+            $affected = DB::table('user_question_progress')
+                ->where('user_id', $user->id)
+                ->whereIn('question_id', $solved)
+                ->where('consecutive_correct', '<', 3)
+                ->update(['consecutive_correct' => 3]);
+
+            $updatedCount += $affected;
+        }
+
+        if ($updatedCount > 0) {
+            \Log::info("Fixed mastery threshold for {$updatedCount} solved question progress records.");
+        }
+    }
+
+    public function down(): void
+    {
+        // Nicht rückgängig machbar - wir wissen nicht welche Einträge
+        // vorher consecutive_correct=2 hatten vs. natürlich auf 3 kamen
+    }
+};


### PR DESCRIPTION
## Summary
Fixes an issue where previously solved questions were incorrectly being included in the practice learning pool due to a mismatch between the initial `consecutive_correct` value (2) and the updated `MASTERY_THRESHOLD` (3).

## Changes
- **PracticeController.php**: Added filtering to exclude solved questions from the learning pool. Solved questions should never be presented as "to learn" items, even if their `consecutive_correct` value is below the mastery threshold (which can occur due to data migrations).

- **Migration**: Added `2026_02_10_000002_fix_solved_questions_mastery_threshold.php` to correct existing data by updating `consecutive_correct` to 3 for all solved questions that have a lower value. This ensures consistency between the database state and the new filtering logic.

## Implementation Details
- The migration iterates through users with solved questions and updates their `user_question_progress` records to meet the current mastery threshold
- Logging is included to track how many records were corrected
- The `down()` method is intentionally left empty since the change is not safely reversible (we cannot distinguish between naturally-reached and migrated values)
- The code change in PracticeController acts as a defensive measure to prevent solved questions from appearing in the learning pool regardless of their progress state

https://claude.ai/code/session_014JYhyyUNfnr1iCCzYtG7rr