### PR TITLE
Improve spaced repetition algorithm with difficulty-based scheduling

### DIFF
--- a/app/Services/SpacedRepetitionService.php
+++ b/app/Services/SpacedRepetitionService.php
@@ -9,16 +9,45 @@ use Carbon\Carbon;
 class SpacedRepetitionService
 {
     /**
-     * SM-2 Algorithmus: Berechnet das nächste Wiederholungsdatum
+     * Globale Schwierigkeit einer Frage anhand der Fehlerquote aller Nutzer.
+     * Gleiche Logik wie PracticeController::getQuestionDifficulty().
+     */
+    private function getGlobalDifficulty(int $questionId): string
+    {
+        $total = \App\Models\QuestionStatistic::where('question_id', $questionId)->count();
+
+        if ($total < 5) {
+            return 'unknown';
+        }
+
+        $correct = \App\Models\QuestionStatistic::where('question_id', $questionId)
+            ->where('is_correct', true)->count();
+        $errorRate = (($total - $correct) / $total) * 100;
+
+        if ($errorRate >= 60) return 'hard';
+        if ($errorRate >= 30) return 'medium';
+        return 'easy';
+    }
+
+    /**
+     * SM-2 Algorithmus: Berechnet das nächste Wiederholungsdatum.
      *
-     * quality: 0-5 (0=komplett falsch, 5=perfekt)
-     * Für unsere Zwecke: falsch=1, richtig=4, gemeistert=5
+     * Richtig: 1 Tag → 3 Tage → exponentiell → 3x = gemeistert (next_review_at = null)
+     * Falsch:  Intervall +1 Tag pro Fehler, Cap je nach globaler Schwierigkeit:
+     *          hard=7 Tage, medium=10 Tage, easy/unknown=14 Tage
      */
     public function calculateNextReview(UserQuestionProgress $progress, bool $isCorrect): void
     {
         $quality = $isCorrect ? ($progress->isMastered() ? 5 : 4) : 1;
+        $difficulty = $this->getGlobalDifficulty($progress->question_id);
 
-        $ef = $progress->easiness_factor ?? 2.5;
+        // EF: initial je nach globaler Schwierigkeit setzen
+        $ef = $progress->easiness_factor ?? match($difficulty) {
+            'hard'   => 2.0,
+            'medium' => 2.3,
+            'easy'   => 2.8,
+            default  => 2.5,
+        };
         $interval = $progress->review_interval ?? 0;
         $repetition = $progress->repetition_count ?? 0;
 
@@ -33,9 +62,14 @@ class SpacedRepetitionService
             }
             $repetition++;
         } else {
-            // Falsch beantwortet - zurücksetzen
+            // Falsch beantwortet: Intervall graduell erhöhen, Cap je nach Schwierigkeit
+            $maxWrongInterval = match($difficulty) {
+                'hard'   => 7,
+                'medium' => 10,
+                default  => 14,
+            };
             $repetition = 0;
-            $interval = 1; // Morgen wieder
+            $interval = min(max(1, $interval + 1), $maxWrongInterval);
         }
 
         // EF aktualisieren (SM-2 Formel)
@@ -48,7 +82,14 @@ class SpacedRepetitionService
         $progress->easiness_factor = round($ef, 1);
         $progress->review_interval = $interval;
         $progress->repetition_count = $repetition;
-        $progress->next_review_at = Carbon::today()->addDays($interval);
+
+        // Gemeisterte Fragen aus SR entfernen – keine weiteren E-Mails
+        if ($progress->isMastered()) {
+            $progress->next_review_at = null;
+        } else {
+            $progress->next_review_at = Carbon::today()->addDays($interval);
+        }
+
         $progress->save();
     }
 

--- a/database/migrations/2026_02_24_000001_null_next_review_at_for_mastered_questions.php
+++ b/database/migrations/2026_02_24_000001_null_next_review_at_for_mastered_questions.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Gemeisterte Fragen (consecutive_correct >= 3) aus der SR-Queue entfernen.
+     * next_review_at = null bedeutet: kein weiteres SR-Scheduling, keine E-Mails.
+     */
+    public function up(): void
+    {
+        DB::table('user_question_progress')
+            ->where('consecutive_correct', '>=', 3)
+            ->update(['next_review_at' => null]);
+    }
+
+    public function down(): void
+    {
+        // Nicht umkehrbar – originale Daten sind nicht gespeichert
+    }
+};


### PR DESCRIPTION
## Summary
Enhanced the spaced repetition service to incorporate global question difficulty into the SM-2 algorithm, providing more intelligent scheduling based on how challenging questions are across all users. Additionally, mastered questions are now removed from the review queue to prevent unnecessary emails.

## Key Changes
- **Added global difficulty calculation**: New `getGlobalDifficulty()` method computes question difficulty based on error rates across all users (hard ≥60%, medium ≥30%, easy <30%)
- **Difficulty-aware initial easiness factor**: Initial EF now varies by difficulty (hard: 2.0, medium: 2.3, easy: 2.8, unknown: 2.5) instead of always defaulting to 2.5
- **Improved wrong answer handling**: When answers are incorrect, the review interval now increases gradually (capped by difficulty: hard=7 days, medium=10 days, easy/unknown=14 days) instead of always resetting to 1 day
- **Mastered question removal**: Questions with 3+ consecutive correct answers now have `next_review_at` set to null, removing them from the spaced repetition queue and preventing further review emails
- **Database migration**: Added migration to set `next_review_at = null` for all currently mastered questions (consecutive_correct ≥ 3)

## Implementation Details
- The difficulty calculation mirrors existing logic from `PracticeController::getQuestionDifficulty()` for consistency
- Mastered questions are identified using the existing `isMastered()` method (3+ consecutive correct)
- The algorithm maintains backward compatibility while providing more nuanced scheduling behavior
- Migration is one-way (down() is not reversible) as original scheduling data is not preserved

https://claude.ai/code/session_01P8KeCMJtQdDd2LtjUEnbyY