### PR TITLE
Exclude future spaced repetition questions from practice mode

### DIFF
--- a/app/Http/Controllers/PracticeController.php
+++ b/app/Http/Controllers/PracticeController.php
@@ -226,6 +226,16 @@ class PracticeController extends Controller
                 $currentlyMasteredIds = UserQuestionProgress::getMasteredQuestions($user->id);
                 $toLearnIds = array_diff($toLearnIds, $currentlyMasteredIds);
 
+                // Fragen ausschließen, die SR bereits für die Zukunft geplant hat.
+                // Wenn next_review_at > now() ist die Frage bereits beantwortet worden und
+                // wird vom SR-Algorithmus erst später wieder eingeblendet – nicht heute nochmal zeigen.
+                $futureSrIds = UserQuestionProgress::where('user_id', $user->id)
+                    ->whereNotNull('next_review_at')
+                    ->where('next_review_at', '>', now())
+                    ->pluck('question_id')
+                    ->toArray();
+                $toLearnIds = array_diff($toLearnIds, $futureSrIds);
+
                 // Nach Lernabschnitten sortiert, innerhalb zufällig
                 $sortedToLearnIds = [];
                 for ($section = 1; $section <= 10; $section++) {
@@ -241,9 +251,11 @@ class PracticeController extends Controller
 
                 // 4. Restliche Fragen zufällig (bereits gemeisterte, keine SR fällig)
                 $remainingIds = array_diff($allQuestionIds, $alreadyQueued);
+                $remainingIds = array_diff($remainingIds, $futureSrIds);
                 $remainingIds = array_values($remainingIds);
                 shuffle($remainingIds);
                 $idsToShow = array_merge($idsToShow, $remainingIds);
+                $idsToShow = array_values(array_unique($idsToShow));
 
                 // Debug-Ausgabe
                 \Log::info('Practice Mode All Debug', [
@@ -252,6 +264,7 @@ class PracticeController extends Controller
                     'failed_count' => count($failedIds),
                     'unmastered_count' => count($unmasteredIds),
                     'never_answered_count' => count($neverAnsweredIds),
+                    'future_sr_excluded' => count($futureSrIds),
                     'total_to_learn' => count($toLearnIds),
                     'remaining_random' => count($remainingIds),
                     'total_ids_to_show' => count($idsToShow),


### PR DESCRIPTION
## Summary
This change prevents questions that are scheduled for future review by the spaced repetition (SR) algorithm from being shown again in practice mode until their scheduled review date arrives.

## Key Changes
- Added logic to identify questions with `next_review_at` dates in the future, indicating they've already been answered and are scheduled for later review by the SR algorithm
- Excluded these future-scheduled questions from the "to learn" pool to avoid showing them prematurely
- Applied the same exclusion to the remaining random questions pool for consistency
- Added deduplication of the final question list to prevent duplicates
- Enhanced debug logging to track the count of excluded future SR questions

## Implementation Details
- Queries `UserQuestionProgress` to find questions where `next_review_at > now()`, which indicates the SR algorithm has already scheduled them for future review
- Uses `array_diff()` to remove these IDs from both the learning queue and remaining questions pool
- Ensures the final question list is deduplicated with `array_unique()` before returning
- Adds a new debug metric `future_sr_excluded` to the practice mode logging for monitoring and troubleshooting

https://claude.ai/code/session_01LpaxGxBQVv4v9PrSX6BMXT