### PR TITLE
Add weekly points reset mechanism for league leaderboards

### DIFF
--- a/app/Services/LeagueService.php
+++ b/app/Services/LeagueService.php
@@ -127,6 +127,10 @@ class LeagueService
      */
     public function getLeagueLeaderboard(string $league): \Illuminate\Support\Collection
     {
+        // Sicherheitsnetz: Stale weekly_points der Vorwoche auf 0 zuruecksetzen,
+        // falls der Weekly-Cron noch nicht gelaufen ist oder User nicht aktiv waren.
+        $this->resetStaleWeeklyPoints();
+
         return User::where('leaderboard_consent', true)
             ->where('league', $league)
             ->where('weekly_points', '>', 0)
@@ -139,6 +143,24 @@ class LeagueService
                 'profile_frame_until', 'profile_frame_type',
                 'rank_color', 'rank_color_until',
                 'active_title', 'active_title_until',
+            ]);
+    }
+
+    /**
+     * Setzt weekly_points aller User zurück, deren letzter Wochen-Reset
+     * vor Beginn der aktuellen Woche liegt (oder nie stattfand).
+     */
+    public function resetStaleWeeklyPoints(): int
+    {
+        $startOfWeek = Carbon::now()->startOfWeek(Carbon::MONDAY);
+
+        return User::where(function ($query) use ($startOfWeek) {
+                $query->whereNull('weekly_reset_at')
+                    ->orWhere('weekly_reset_at', '<', $startOfWeek);
+            })
+            ->update([
+                'weekly_points' => 0,
+                'weekly_reset_at' => $startOfWeek,
             ]);
     }
 
@@ -258,6 +280,14 @@ class LeagueService
                 }
             }
         }
+
+        // Nach Auf-/Abstiegen und Lootbox-Vergabe: weekly_points aller User zuruecksetzen,
+        // damit inaktive User in der neuen Woche nicht mit altem Score im Leaderboard stehen.
+        $startOfWeek = Carbon::now()->startOfWeek(Carbon::MONDAY);
+        User::query()->update([
+            'weekly_points' => 0,
+            'weekly_reset_at' => $startOfWeek,
+        ]);
 
         Log::info('Wöchentliche Liga-Verarbeitung abgeschlossen', $results);
 


### PR DESCRIPTION
## Summary
This PR implements a safety mechanism to reset stale weekly points for users in league leaderboards. It ensures that inactive users or those whose weekly reset hasn't run don't appear with outdated scores on the leaderboard.

## Key Changes
- **New `resetStaleWeeklyPoints()` method**: Resets `weekly_points` to 0 for users whose last weekly reset occurred before the current week started (or never occurred). This method is idempotent and tracks the reset timestamp via `weekly_reset_at`.

- **Leaderboard safety net**: Integrated `resetStaleWeeklyPoints()` into `getLeagueLeaderboard()` to ensure stale points are cleaned up before displaying rankings, providing a fallback if the weekly cron hasn't run yet.

- **Weekly processing cleanup**: Added a comprehensive reset in `processWeeklyLeagues()` that resets all users' `weekly_points` to 0 after promotions/demotions and loot box distribution, ensuring a clean slate for the new week.

## Implementation Details
- Uses `Carbon::now()->startOfWeek(Carbon::MONDAY)` to determine week boundaries
- The `resetStaleWeeklyPoints()` method returns the count of affected users for logging/monitoring
- Handles both null `weekly_reset_at` values (never reset) and stale timestamps
- All changes are in German comments, consistent with existing codebase style

https://claude.ai/code/session_01KQPAkZ74WYUQwhioRj9Apc