### PR TITLE
✨: Fortschrittsstufen sichtbar

### DIFF
--- a/app/Http/Controllers/PracticeController.php
+++ b/app/Http/Controllers/PracticeController.php
@@ -606,7 +606,9 @@ class PracticeController extends Controller
         $totalQuestions = Question::count();
         $total = $totalQuestions;
         $progress = UserQuestionProgress::countMastered($user->id);
-        
+        $progressOnce = UserQuestionProgress::countAtLevel($user->id, 1);
+        $progressTwice = UserQuestionProgress::countAtLevel($user->id, 2);
+
         // Neue Fortschrittsbalken-Logik: Berücksichtigt auch 1x richtige Antworten
         $threshold = UserQuestionProgress::MASTERY_THRESHOLD;
         $progressData = UserQuestionProgress::where('user_id', $user->id)->get();
@@ -637,7 +639,7 @@ class PracticeController extends Controller
         $srDueIds = $srService->getDueQuestions($user->id);
         $isSpacedRepetition = in_array($question->id, $srDueIds);
 
-        return view('practice', compact('question', 'progress', 'total', 'mode', 'progressPercent', 'totalInMode', 'currentInMode', 'difficultyInfo', 'isSpacedRepetition'));
+        return view('practice', compact('question', 'progress', 'progressOnce', 'progressTwice', 'total', 'mode', 'progressPercent', 'totalInMode', 'currentInMode', 'difficultyInfo', 'isSpacedRepetition'));
     }
 
     public function show(Request $request)
@@ -705,6 +707,8 @@ class PracticeController extends Controller
 
             $total = Question::count();
             $progress = UserQuestionProgress::countMastered($user->id);
+            $progressOnce = UserQuestionProgress::countAtLevel($user->id, 1);
+            $progressTwice = UserQuestionProgress::countAtLevel($user->id, 2);
 
             // Neue Fortschrittsbalken-Logik: Berücksichtigt auch 1x richtige Antworten
             $threshold = UserQuestionProgress::MASTERY_THRESHOLD;
@@ -736,7 +740,7 @@ class PracticeController extends Controller
         $serviceProgress = $this->practiceService->getProgress('global', null);
 
         return view('practice', compact(
-            'question', 'progress', 'total', 'mode', 'progressPercent',
+            'question', 'progress', 'progressOnce', 'progressTwice', 'total', 'mode', 'progressPercent',
             'totalInMode', 'currentInMode', 'difficultyInfo', 'isSpacedRepetition',
             'answerResult', 'gamificationResult'
         ) + [

--- a/app/Models/UserQuestionProgress.php
+++ b/app/Models/UserQuestionProgress.php
@@ -119,5 +119,15 @@ class UserQuestionProgress extends Model
             ->where('consecutive_correct', '>=', self::MASTERY_THRESHOLD)
             ->count();
     }
+
+    /**
+     * Zähle Fragen mit genau X aufeinanderfolgenden richtigen Antworten
+     */
+    public static function countAtLevel(int $userId, int $level): int
+    {
+        return self::where('user_id', $userId)
+            ->where('consecutive_correct', $level)
+            ->count();
+    }
 }
 

--- a/resources/views/practice.blade.php
+++ b/resources/views/practice.blade.php
@@ -1155,10 +1155,16 @@
                     <div class="practice-title">{{ $contextLabel ?? 'Theorie üben' }}</div>
                     <div class="practice-level-line">
                         <span>
-                            {{ $progress }}/{{ $total }} gemeistert &middot; {{ $progressPercent ?? 0 }}%
+                            <span style="opacity:0.75;">1× richtig: {{ $progressOnce ?? 0 }}</span>
+                            &middot;
+                            <span style="opacity:0.75;">2× richtig: {{ $progressTwice ?? 0 }}</span>
+                            &middot;
+                            {{ $progress }}/{{ $total }} gemeistert
+                            &middot;
+                            {{ $progressPercent ?? 0 }}%
                             <i class="bi bi-info-circle"
                                style="font-size:0.85rem; color: rgba(255,255,255,0.5); cursor: help; margin-left: 0.25rem;"
-                               title="Eine Frage gilt als gemeistert, wenn du sie 3× hintereinander richtig beantwortet hast. Der Prozentbalken steigt bereits bei der ersten richtigen Antwort."></i>
+                               title="Gemeistert = 3× hintereinander richtig beantwortet. Eine falsche Antwort setzt den Zähler zurück auf 0."></i>
                         </span>
                         <div class="practice-xp-bar">
                             <div class="practice-xp-fill" style="width: {{ $progressPercent ?? 0 }}%;"></div>


### PR DESCRIPTION
Zeigt im Practice-Header zusätzlich "1× richtig" und "2× richtig" Counter neben "gemeistert". User sehen nach jeder richtigen Antwort direkten Fortschritt, statt auf den Sprung zu 3× in Folge zu warten.