### PR TITLE
Improve exam mode layout and footer visibility across breakpoints

### DIFF
--- a/resources/views/exam.blade.php
+++ b/resources/views/exam.blade.php
@@ -11,13 +11,17 @@
    Mobile-First, Fullscreen, Sliding Bubbles
    ============================================ */
 
+/* ── Footer während Prüfung ausblenden (alle Breakpoints) ─── */
+.exam-active-mode footer {
+    display: none !important;
+}
+
 /* ── Mobile: Fullscreen Takeover ─────────────── */
 @media (max-width: 640px) {
     html, body {
         height: 100dvh !important;
         overflow: hidden !important;
     }
-    .exam-active-mode footer,
     .exam-active-mode nav,
     .exam-active-mode header {
         display: none !important;
@@ -35,6 +39,17 @@
     max-width: 900px;
     margin: 0 auto;
     padding: 1.5rem;
+}
+
+@media (min-width: 641px) {
+    .exam-shell {
+        display: flex;
+        flex-direction: column;
+        min-height: calc(100vh - 4rem);
+    }
+    .exam-content {
+        flex: 1 0 auto;
+    }
 }
 
 @media (max-width: 640px) {
@@ -560,16 +575,23 @@ html.light-mode .exam-bottom-bar {
 }
 
 @media (min-width: 641px) {
+    .exam-shell {
+        padding-bottom: 0;
+    }
     .exam-bottom-bar {
-        background: transparent;
-        border-top: none;
-        padding: 0;
-        margin-top: 1rem;
+        position: sticky;
+        bottom: 0;
+        z-index: 50;
+        background: rgba(10, 10, 11, 0.75);
+        -webkit-backdrop-filter: blur(20px) saturate(180%);
+        backdrop-filter: blur(20px) saturate(180%);
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+        padding: 0.875rem 1.5rem;
+        margin: 1rem -1.5rem 0;
     }
     html.light-mode .exam-bottom-bar {
-        background: transparent;
-        border-top: none;
-        backdrop-filter: none;
+        background: rgba(243, 244, 246, 0.75);
+        border-top-color: rgba(0, 51, 127, 0.1);
     }
 }
 


### PR DESCRIPTION
## Summary
This PR refines the exam mode styling to improve layout consistency and footer visibility across different screen sizes. The changes ensure the footer is properly hidden during exams on all devices and implement a sticky bottom bar for desktop with improved visual styling.

## Key Changes
- **Footer hiding**: Moved footer display rule outside media queries to ensure it's hidden on all breakpoints during exam mode, not just mobile
- **Desktop layout improvements**: Added flexbox layout for exam shell on desktop (641px+) to properly manage content spacing and ensure the bottom bar stays at the bottom
- **Bottom bar styling**: Transformed the exam bottom bar from a transparent element to a sticky, frosted-glass styled component on desktop with:
  - Sticky positioning at the bottom with proper z-index
  - Semi-transparent dark background with backdrop blur effect
  - Subtle border styling for visual separation
  - Light mode variant with appropriate colors
- **Spacing adjustments**: Updated padding and margins to work with the new sticky positioning and flexbox layout

## Implementation Details
- The footer is now hidden globally for `.exam-active-mode` using `!important` to override any specificity issues
- Desktop exam shell uses `min-height: calc(100vh - 4rem)` to account for the footer height
- The bottom bar uses `backdrop-filter` with blur and saturation for a modern frosted-glass effect
- Light mode styling ensures proper contrast with `rgba(243, 244, 246, 0.75)` background

https://claude.ai/code/session_011MvF84uxMuiwyHHroCZktb