### PR TITLE
📦: Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versionierung: [Semantic Versioning](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-04-17
+
+### Intern
+
+- Exam-Modus Layout und Footer-Sichtbarkeit über Breakpoints verbessert (#456, @niclasreutter)
+- Icons für verschiedene Zwecke angepasst, Dark/Lightmode-Favicon hinzugefügt (#455, @thmsnhl)
+
 ## [1.0.0] - 2026-04-16
 
 Erste offizielle Version. Bündelt die bisherige Entwicklungshistorie
@@ -101,4 +108,5 @@ Erste offizielle Version. Bündelt die bisherige Entwicklungshistorie
 
 (~15 sonstige PRs zusammengefasst)
 
+[1.0.1]: https://github.com/niclasreutter/THW-Trainer-App/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/niclasreutter/THW-Trainer-App/commits/main

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "The skeleton application for the Laravel framework.",
     "keywords": ["laravel", "framework"],
     "license": "MIT",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "require": {
         "php": "^8.2",
         "laravel-lang/common": "^6.7",


### PR DESCRIPTION
## [1.0.1] - 2026-04-17

### Intern

- Exam-Modus Layout und Footer-Sichtbarkeit über Breakpoints verbessert (#456, @niclasreutter)
- Icons für verschiedene Zwecke angepasst, Dark/Lightmode-Favicon hinzugefügt (#455, @thmsnhl)

---

Nach Merge: `npm run build && php artisan view:clear && php artisan cache:clear`