### PR TITLE
🎨: Zusatz-Fragen Design-File

### DIFF
--- a/resources/views/admin/extra-questions/create.blade.php
+++ b/resources/views/admin/extra-questions/create.blade.php
@@ -2,203 +2,65 @@
 @section('title', 'Neue Zusatz-Frage - THW Trainer Admin')
 
 @push('styles')
-<style>
-    .typ-picker {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 1rem;
-        margin-bottom: 1.5rem;
-    }
-    .typ-card {
-        padding: 1.25rem;
-        border-radius: 0.75rem;
-        border: 2px solid rgba(255,255,255,0.08);
-        background: rgba(255,255,255,0.02);
-        cursor: pointer;
-        transition: all 0.2s;
-        text-align: left;
-        color: var(--text-primary);
-        font: inherit;
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-    }
-    .typ-card:hover {
-        border-color: var(--gold-start);
-        background: rgba(255,255,255,0.04);
-        transform: translateY(-2px);
-    }
-    .typ-card.active {
-        border-color: var(--gold-start);
-        background: linear-gradient(135deg, rgba(251,191,36,0.08), rgba(245,158,11,0.03));
-        box-shadow: 0 0 0 3px rgba(251,191,36,0.15);
-    }
-    .typ-card .typ-icon {
-        font-size: 1.5rem;
-        color: var(--gold-start);
-    }
-    .typ-card h3 {
-        font-size: 1rem;
-        font-weight: 700;
-        margin: 0;
-    }
-    .typ-card p {
-        font-size: 0.82rem;
-        color: var(--text-muted);
-        margin: 0;
-        line-height: 1.4;
-    }
-
-    .field-label {
-        display: block;
-        font-weight: 600;
-        font-size: 0.85rem;
-        margin-bottom: 0.4rem;
-    }
-    .field-required { color: var(--error); }
-
-    .field-input,
-    .field-textarea {
-        width: 100%;
-        padding: 0.65rem 0.75rem;
-        border: 1px solid rgba(255,255,255,0.1);
-        background: rgba(255,255,255,0.03);
-        border-radius: 0.5rem;
-        color: var(--text-primary);
-        font: inherit;
-        outline: none;
-        transition: all 0.15s;
-    }
-    .field-input:focus,
-    .field-textarea:focus {
-        border-color: var(--gold-start);
-        background: rgba(255,255,255,0.06);
-    }
-    .field-textarea { min-height: 90px; resize: vertical; }
-
-    .field-error {
-        display: block;
-        margin-top: 0.35rem;
-        color: var(--error);
-        font-size: 0.8rem;
-    }
-
-    .form-row {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 1rem;
-        margin-bottom: 1.25rem;
-    }
-
-    .dyn-row {
-        display: flex;
-        gap: 0.6rem;
-        align-items: flex-start;
-        padding: 0.75rem;
-        border: 1px solid rgba(255,255,255,0.08);
-        border-radius: 0.5rem;
-        background: rgba(255,255,255,0.02);
-        margin-bottom: 0.6rem;
-    }
-    .dyn-row .dyn-index {
-        font-weight: 700;
-        color: var(--text-muted);
-        font-size: 0.85rem;
-        min-width: 1.5rem;
-        padding-top: 0.5rem;
-    }
-    .dyn-row .dyn-body { flex: 1; display: flex; flex-direction: column; gap: 0.5rem; }
-
-    .btn-icon-remove {
-        padding: 0.4rem 0.6rem;
-        border: 1px solid rgba(239,68,68,0.25);
-        background: rgba(239,68,68,0.08);
-        color: #fca5a5;
-        border-radius: 0.4rem;
-        cursor: pointer;
-        font-size: 0.8rem;
-        transition: all 0.15s;
-    }
-    .btn-icon-remove:hover { background: rgba(239,68,68,0.16); color: #fff; }
-    .btn-icon-remove:disabled { opacity: 0.4; cursor: not-allowed; }
-
-    .btn-add-row {
-        padding: 0.55rem 0.9rem;
-        border: 1px dashed rgba(255,255,255,0.2);
-        background: transparent;
-        color: var(--text-secondary);
-        border-radius: 0.5rem;
-        cursor: pointer;
-        font-size: 0.85rem;
-        font-weight: 600;
-        transition: all 0.15s;
-        width: 100%;
-    }
-    .btn-add-row:hover:not(:disabled) {
-        border-color: var(--gold-start);
-        color: var(--gold-start);
-        background: rgba(251,191,36,0.04);
-    }
-    .btn-add-row:disabled { opacity: 0.4; cursor: not-allowed; }
-
-    .checkbox-inline {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        font-size: 0.85rem;
-        cursor: pointer;
-        user-select: none;
-    }
-
-    .image-preview {
-        margin-top: 0.5rem;
-        max-width: 280px;
-        border-radius: 0.5rem;
-        overflow: hidden;
-        border: 1px solid rgba(255,255,255,0.1);
-    }
-    .image-preview img { width: 100%; height: auto; display: block; }
-
-    .file-field {
-        padding: 0.55rem;
-        border: 1px dashed rgba(255,255,255,0.15);
-        border-radius: 0.5rem;
-        background: rgba(255,255,255,0.02);
-    }
-
-    .form-actions {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        margin-top: 1.5rem;
-        padding-top: 1.25rem;
-        border-top: 1px solid rgba(255,255,255,0.06);
-        gap: 0.75rem;
-        flex-wrap: wrap;
-    }
-
-    .hint {
-        font-size: 0.78rem;
-        color: var(--text-muted);
-        margin-top: 0.35rem;
-        line-height: 1.4;
-    }
-</style>
+@include('admin.extra-questions.partials._styles')
 @endpush
 
 @section('content')
-<div class="dashboard-container">
-    <header class="dashboard-header">
-        <h1 class="page-title">Neue <span>Zusatz-Frage</span></h1>
-        <p class="page-subtitle">Fragetyp wählen und Inhalte anlegen</p>
-    </header>
+@php
+    $typeOptions = [
+        [
+            'key'   => 'matching',
+            'icon'  => 'bi-diagram-3-fill',
+            'title' => 'Zuordnung',
+            'desc'  => 'Items zu Kategorien zuordnen (2–5 Kategorien, 3–10 Items)',
+        ],
+        [
+            'key'   => 'image_name',
+            'icon'  => 'bi-image-fill',
+            'title' => 'Bild benennen',
+            'desc'  => 'Ein Bild anzeigen, Nutzer wählt aus 2–6 Text-Optionen',
+        ],
+        [
+            'key'   => 'image_select',
+            'icon'  => 'bi-grid-3x3-gap-fill',
+            'title' => 'Bild auswählen',
+            'desc'  => 'Textfrage mit 2–6 Bild-Optionen (ein oder mehrere korrekt)',
+        ],
+    ];
+
+    $sections = [
+        '1'  => '1 – Das THW im Gefüge',
+        '2'  => '2 – Persönliche Ausrüstung',
+        '3'  => '3 – UVV und Rettung',
+        '4'  => '4 – Stromerzeuger & Beleuchtung',
+        '5'  => '5 – Rettungs- und Bergungsarbeiten',
+        '6'  => '6 – Knoten und Stiche',
+        '7'  => '7 – Leitern',
+        '8'  => '8 – Transportieren von Lasten',
+        '9'  => '9 – Einfache Holzverbindungen',
+        '10' => '10 – Erste Hilfe',
+    ];
+@endphp
+
+<div class="dash-container" style="max-width: 52rem;">
+    <div style="margin-bottom: 0.75rem;">
+        <a href="{{ route('admin.extra-questions.index') }}" class="zf-back-btn">
+            <i class="bi bi-arrow-left"></i> Zurück zu Zusatz-Fragen
+        </a>
+    </div>
+
+    <div class="zf-page-title">
+        <div class="zf-page-title__eyebrow">Admin · Zusatz-Fragen</div>
+        <h1 class="zf-page-title__h1">Neue Zusatz-Frage</h1>
+        <div class="zf-page-title__sub">Fragetyp wählen und Inhalte anlegen</div>
+    </div>
 
     @if($errors->any())
-        <div class="glass-error" style="padding: 1.25rem; margin-bottom: 1.5rem; display: flex; gap: 1rem; align-items: flex-start;">
-            <i class="bi bi-x-circle" style="font-size: 1.25rem; flex-shrink: 0;"></i>
+        <div class="zf-alert zf-alert--error">
+            <i class="bi bi-x-circle-fill"></i>
             <div>
                 <strong>Bitte korrigiere folgende Fehler:</strong>
-                <ul style="margin: 0.35rem 0 0 0; padding-left: 1.25rem;">
+                <ul>
                     @foreach($errors->all() as $error)
                         <li>{{ $error }}</li>
                     @endforeach
@@ -208,62 +70,62 @@
     @endif
 
     <div x-data="{ typ: @js(old('typ', $typ)) }">
-        {{-- Typ-Auswahl --}}
-        <div class="glass-tl" style="padding: 1.5rem; margin-bottom: 1.5rem;">
-            <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start); margin-bottom: 1rem;">
-                <h2 class="section-title" style="font-size: 1.05rem;">Fragetyp</h2>
+        {{-- Fragetyp-Auswahl --}}
+        <div class="zf-form-card">
+            <div class="zf-form-card__label">
+                <span class="zf-section-label">Fragetyp</span>
             </div>
-            <div class="typ-picker">
-                <button type="button" class="typ-card" :class="{ active: typ === 'matching' }" @click="typ = 'matching'">
-                    <span class="typ-icon"><i class="bi bi-diagram-3"></i></span>
-                    <h3>Zuordnung</h3>
-                    <p>Items zu Kategorien zuordnen (2–5 Kategorien, 3–10 Items).</p>
-                </button>
-                <button type="button" class="typ-card" :class="{ active: typ === 'image_name' }" @click="typ = 'image_name'">
-                    <span class="typ-icon"><i class="bi bi-image"></i></span>
-                    <h3>Bild benennen</h3>
-                    <p>Ein Bild zeigen, Nutzer wählt passenden Namen aus 2–6 Text-Optionen.</p>
-                </button>
-                <button type="button" class="typ-card" :class="{ active: typ === 'image_select' }" @click="typ = 'image_select'">
-                    <span class="typ-icon"><i class="bi bi-grid-3x3-gap"></i></span>
-                    <h3>Bild auswählen</h3>
-                    <p>Textfrage mit 2–6 Bild-Optionen. Ein oder mehrere Bilder können korrekt sein.</p>
-                </button>
+            <div class="zf-type-grid">
+                @foreach($typeOptions as $opt)
+                    <button type="button"
+                            class="zf-type-card"
+                            :class="{ 'is-selected': typ === '{{ $opt['key'] }}' }"
+                            @click="typ = '{{ $opt['key'] }}'">
+                        <div class="zf-type-card__check"><i class="bi bi-check-lg"></i></div>
+                        <div class="zf-type-card__icon"><i class="bi {{ $opt['icon'] }}"></i></div>
+                        <div class="zf-type-card__title">{{ $opt['title'] }}</div>
+                        <div class="zf-type-card__desc">{{ $opt['desc'] }}</div>
+                    </button>
+                @endforeach
             </div>
         </div>
 
-        {{-- Formular --}}
         <form method="POST" action="{{ route('admin.extra-questions.store') }}" enctype="multipart/form-data" x-show="typ" x-cloak>
             @csrf
             <input type="hidden" name="typ" :value="typ">
 
-            <div class="glass" style="padding: 1.5rem; margin-bottom: 1.25rem;">
-                <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start); margin-bottom: 1rem;">
-                    <h2 class="section-title" style="font-size: 1.05rem;">Allgemein</h2>
+            {{-- Allgemein --}}
+            <div class="zf-form-card">
+                <div class="zf-form-card__label">
+                    <span class="zf-section-label">Allgemein</span>
                 </div>
 
-                <div class="form-row">
-                    <div>
-                        <label class="field-label" for="lernabschnitt">
-                            Lernabschnitt <span class="field-required">*</span>
-                        </label>
-                        <input id="lernabschnitt" type="text" name="lernabschnitt" value="{{ old('lernabschnitt') }}"
-                               class="field-input" placeholder="z.B. 1" required>
-                        @error('lernabschnitt')<span class="field-error">{{ $message }}</span>@enderror
-                    </div>
-                </div>
-
-                <div style="margin-bottom: 0.5rem;">
-                    <label class="field-label" for="frage">
-                        Frage-Text <span class="field-required">*</span>
+                <div class="zf-field">
+                    <label class="zf-label" for="lernabschnitt">
+                        Lernabschnitt <span class="zf-req">*</span>
                     </label>
-                    <textarea id="frage" name="frage" class="field-textarea" required
-                              placeholder="Fragentext eingeben...">{{ old('frage') }}</textarea>
-                    @error('frage')<span class="field-error">{{ $message }}</span>@enderror
+                    <select id="lernabschnitt" name="lernabschnitt" class="zf-select" required>
+                        @foreach($sections as $val => $label)
+                            <option value="{{ $val }}" {{ old('lernabschnitt') == $val ? 'selected' : '' }}>
+                                {{ $label }}
+                            </option>
+                        @endforeach
+                    </select>
+                    @error('lernabschnitt')<span class="zf-field-error">{{ $message }}</span>@enderror
+                </div>
+
+                <div class="zf-field">
+                    <label class="zf-label" for="frage">
+                        Frage-Titel <span class="zf-req">*</span>
+                    </label>
+                    <textarea id="frage" name="frage" class="zf-textarea" required
+                              placeholder="z.B. Ordne die Knoten den Einsatzzwecken zu">{{ old('frage') }}</textarea>
+                    <span class="zf-help">Wird als Frage-Stellung angezeigt.</span>
+                    @error('frage')<span class="zf-field-error">{{ $message }}</span>@enderror
                 </div>
             </div>
 
-            {{-- Dynamische Partials je Typ --}}
+            {{-- Typ-spezifische Partials --}}
             <div x-show="typ === 'matching'" x-cloak>
                 @include('admin.extra-questions.partials.form-matching', ['question' => null])
             </div>
@@ -276,14 +138,16 @@
                 @include('admin.extra-questions.partials.form-image-select', ['question' => null])
             </div>
 
-            <div class="form-actions">
+            <div class="zf-form-actions">
                 <a href="{{ route('admin.extra-questions.index') }}" class="btn-ghost">Abbrechen</a>
-                <button type="submit" class="btn-primary">Zusatz-Frage speichern</button>
+                <button type="submit" class="btn-primary">
+                    <i class="bi bi-check2"></i> Zusatz-Frage speichern
+                </button>
             </div>
         </form>
 
-        <div x-show="!typ" x-cloak class="glass" style="padding: 2rem; text-align: center; color: var(--text-muted);">
-            <div style="font-size: 2rem; margin-bottom: 0.75rem; opacity: 0.5;">
+        <div x-show="!typ" x-cloak class="zf-form-card" style="text-align: center; padding: 2rem; color: var(--text-muted);">
+            <div style="font-size: 1.5rem; margin-bottom: 0.75rem; color: var(--thw-blue);">
                 <i class="bi bi-arrow-up-circle"></i>
             </div>
             <p style="margin: 0;">Wähle oben einen Fragetyp, um das Formular zu laden.</p>

--- a/resources/views/admin/extra-questions/edit.blade.php
+++ b/resources/views/admin/extra-questions/edit.blade.php
@@ -2,175 +2,99 @@
 @section('title', 'Zusatz-Frage bearbeiten - THW Trainer Admin')
 
 @push('styles')
+@include('admin.extra-questions.partials._styles')
 <style>
-    .typ-display {
+    .zf-type-display {
         display: inline-flex;
         align-items: center;
-        gap: 0.5rem;
-        padding: 0.4rem 0.8rem;
+        gap: 0.4rem;
+        padding: 0.3rem 0.7rem;
         border-radius: 999px;
-        font-size: 0.82rem;
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        font-size: 0.6875rem;
         font-weight: 700;
-        background: rgba(251,191,36,0.08);
-        border: 1px solid rgba(251,191,36,0.25);
-        color: var(--gold-start);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        background: rgba(0, 51, 127, 0.08);
+        color: var(--thw-blue);
+    }
+    html:not(.light-mode) .zf-type-display {
+        background: rgba(91, 154, 255, 0.12);
+        color: #5b9aff;
     }
 
-    .field-label { display: block; font-weight: 600; font-size: 0.85rem; margin-bottom: 0.4rem; }
-    .field-required { color: var(--error); }
-
-    .field-input, .field-textarea {
-        width: 100%;
-        padding: 0.65rem 0.75rem;
-        border: 1px solid rgba(255,255,255,0.1);
-        background: rgba(255,255,255,0.03);
-        border-radius: 0.5rem;
-        color: var(--text-primary);
-        font: inherit;
-        outline: none;
-        transition: all 0.15s;
-    }
-    .field-input:focus, .field-textarea:focus {
-        border-color: var(--gold-start);
-        background: rgba(255,255,255,0.06);
-    }
-    .field-textarea { min-height: 90px; resize: vertical; }
-
-    .field-error { display: block; margin-top: 0.35rem; color: var(--error); font-size: 0.8rem; }
-
-    .form-row {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 1rem;
-        margin-bottom: 1.25rem;
-    }
-
-    .dyn-row {
-        display: flex;
-        gap: 0.6rem;
-        align-items: flex-start;
-        padding: 0.75rem;
-        border: 1px solid rgba(255,255,255,0.08);
-        border-radius: 0.5rem;
-        background: rgba(255,255,255,0.02);
-        margin-bottom: 0.6rem;
-    }
-    .dyn-row .dyn-index {
-        font-weight: 700;
-        color: var(--text-muted);
-        font-size: 0.85rem;
-        min-width: 1.5rem;
-        padding-top: 0.5rem;
-    }
-    .dyn-row .dyn-body { flex: 1; display: flex; flex-direction: column; gap: 0.5rem; }
-
-    .btn-icon-remove {
-        padding: 0.4rem 0.6rem;
-        border: 1px solid rgba(239,68,68,0.25);
-        background: rgba(239,68,68,0.08);
-        color: #fca5a5;
-        border-radius: 0.4rem;
-        cursor: pointer;
-        font-size: 0.8rem;
-    }
-    .btn-icon-remove:hover { background: rgba(239,68,68,0.16); color: #fff; }
-    .btn-icon-remove:disabled { opacity: 0.4; cursor: not-allowed; }
-
-    .btn-add-row {
-        padding: 0.55rem 0.9rem;
-        border: 1px dashed rgba(255,255,255,0.2);
-        background: transparent;
-        color: var(--text-secondary);
-        border-radius: 0.5rem;
-        cursor: pointer;
-        font-size: 0.85rem;
-        font-weight: 600;
-        width: 100%;
-    }
-    .btn-add-row:hover:not(:disabled) {
-        border-color: var(--gold-start);
-        color: var(--gold-start);
-        background: rgba(251,191,36,0.04);
-    }
-    .btn-add-row:disabled { opacity: 0.4; cursor: not-allowed; }
-
-    .checkbox-inline {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        font-size: 0.85rem;
-        cursor: pointer;
-        user-select: none;
-    }
-
-    .image-preview {
-        margin-top: 0.5rem;
-        max-width: 280px;
-        border-radius: 0.5rem;
-        overflow: hidden;
-        border: 1px solid rgba(255,255,255,0.1);
-    }
-    .image-preview img { width: 100%; height: auto; display: block; }
-
-    .file-field {
-        padding: 0.55rem;
-        border: 1px dashed rgba(255,255,255,0.15);
-        border-radius: 0.5rem;
-        background: rgba(255,255,255,0.02);
-    }
-
-    .form-actions {
+    .zf-danger-zone {
+        padding: 1rem 1.25rem;
+        margin-top: 1.25rem;
+        border-radius: 0.75rem;
+        background: rgba(239, 68, 68, 0.05);
+        border: 1px solid rgba(239, 68, 68, 0.20);
         display: flex;
         justify-content: space-between;
         align-items: center;
-        margin-top: 1.5rem;
-        padding-top: 1.25rem;
-        border-top: 1px solid rgba(255,255,255,0.06);
-        gap: 0.75rem;
+        gap: 1rem;
         flex-wrap: wrap;
     }
-
-    .hint {
-        font-size: 0.78rem;
-        color: var(--text-muted);
-        margin-top: 0.35rem;
-        line-height: 1.4;
-    }
+    .zf-danger-zone strong { color: #ef4444; }
+    .zf-danger-zone__meta { font-size: 0.8rem; color: var(--text-muted); margin: 0.25rem 0 0; }
 </style>
 @endpush
 
 @section('content')
 @php
     $typLabels = [
-        'matching' => 'Zuordnung',
-        'image_name' => 'Bild benennen',
+        'matching'     => 'Zuordnung',
+        'image_name'   => 'Bild benennen',
         'image_select' => 'Bild auswählen',
     ];
     $typIcons = [
-        'matching' => 'bi-diagram-3',
-        'image_name' => 'bi-image',
-        'image_select' => 'bi-grid-3x3-gap',
+        'matching'     => 'bi-diagram-3-fill',
+        'image_name'   => 'bi-image-fill',
+        'image_select' => 'bi-grid-3x3-gap-fill',
     ];
+
+    $sections = [
+        '1'  => '1 – Das THW im Gefüge',
+        '2'  => '2 – Persönliche Ausrüstung',
+        '3'  => '3 – UVV und Rettung',
+        '4'  => '4 – Stromerzeuger & Beleuchtung',
+        '5'  => '5 – Rettungs- und Bergungsarbeiten',
+        '6'  => '6 – Knoten und Stiche',
+        '7'  => '7 – Leitern',
+        '8'  => '8 – Transportieren von Lasten',
+        '9'  => '9 – Einfache Holzverbindungen',
+        '10' => '10 – Erste Hilfe',
+    ];
+    $currentLern = (string) old('lernabschnitt', $question->lernabschnitt);
+    $hasPredefinedLern = isset($sections[$currentLern]);
 @endphp
-<div class="dashboard-container">
-    <header class="dashboard-header">
-        <h1 class="page-title">Zusatz-Frage <span>bearbeiten</span></h1>
-        <p class="page-subtitle">ID #{{ $question->id }} &middot; Typ ist gesperrt, Inhalte können geändert werden</p>
-    </header>
+
+<div class="dash-container" style="max-width: 52rem;">
+    <div style="margin-bottom: 0.75rem;">
+        <a href="{{ route('admin.extra-questions.index') }}" class="zf-back-btn">
+            <i class="bi bi-arrow-left"></i> Zurück zu Zusatz-Fragen
+        </a>
+    </div>
+
+    <div class="zf-page-title">
+        <div class="zf-page-title__eyebrow">Admin · Zusatz-Fragen · #{{ $question->id }}</div>
+        <h1 class="zf-page-title__h1">Zusatz-Frage bearbeiten</h1>
+        <div class="zf-page-title__sub">Typ ist gesperrt, Inhalte können geändert werden</div>
+    </div>
 
     @if(session('success'))
-        <div class="glass-success" style="padding: 1.25rem; margin-bottom: 1.5rem; display: flex; gap: 1rem; align-items: flex-start;">
-            <i class="bi bi-check-circle" style="font-size: 1.25rem; flex-shrink: 0;"></i>
-            <div><strong>Erfolg!</strong><p style="margin: 0.25rem 0 0 0;">{{ session('success') }}</p></div>
+        <div class="zf-alert zf-alert--success">
+            <i class="bi bi-check-circle-fill"></i>
+            <div><strong>Erfolg!</strong>{{ session('success') }}</div>
         </div>
     @endif
 
     @if($errors->any())
-        <div class="glass-error" style="padding: 1.25rem; margin-bottom: 1.5rem; display: flex; gap: 1rem; align-items: flex-start;">
-            <i class="bi bi-x-circle" style="font-size: 1.25rem; flex-shrink: 0;"></i>
+        <div class="zf-alert zf-alert--error">
+            <i class="bi bi-x-circle-fill"></i>
             <div>
                 <strong>Bitte korrigiere folgende Fehler:</strong>
-                <ul style="margin: 0.35rem 0 0 0; padding-left: 1.25rem;">
+                <ul>
                     @foreach($errors->all() as $error)
                         <li>{{ $error }}</li>
                     @endforeach
@@ -183,35 +107,41 @@
         @csrf
         @method('PUT')
 
-        <div class="glass" style="padding: 1.5rem; margin-bottom: 1.25rem;">
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; gap: 1rem; flex-wrap: wrap;">
-                <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start);">
-                    <h2 class="section-title" style="font-size: 1.05rem;">Allgemein</h2>
-                </div>
-                <span class="typ-display">
+        <div class="zf-form-card">
+            <div class="zf-form-card__label">
+                <span class="zf-section-label">Allgemein</span>
+                <span class="zf-type-display">
                     <i class="bi {{ $typIcons[$question->typ] ?? 'bi-question' }}"></i>
                     {{ $typLabels[$question->typ] ?? $question->typ }}
                 </span>
             </div>
 
-            <div class="form-row">
-                <div>
-                    <label class="field-label" for="lernabschnitt">
-                        Lernabschnitt <span class="field-required">*</span>
-                    </label>
+            <div class="zf-field">
+                <label class="zf-label" for="lernabschnitt">
+                    Lernabschnitt <span class="zf-req">*</span>
+                </label>
+                @if($hasPredefinedLern)
+                    <select id="lernabschnitt" name="lernabschnitt" class="zf-select" required>
+                        @foreach($sections as $val => $label)
+                            <option value="{{ $val }}" {{ $currentLern === (string) $val ? 'selected' : '' }}>
+                                {{ $label }}
+                            </option>
+                        @endforeach
+                    </select>
+                @else
                     <input id="lernabschnitt" type="text" name="lernabschnitt"
-                           value="{{ old('lernabschnitt', $question->lernabschnitt) }}"
-                           class="field-input" required>
-                    @error('lernabschnitt')<span class="field-error">{{ $message }}</span>@enderror
-                </div>
+                           value="{{ $currentLern }}"
+                           class="zf-input" required>
+                @endif
+                @error('lernabschnitt')<span class="zf-field-error">{{ $message }}</span>@enderror
             </div>
 
-            <div>
-                <label class="field-label" for="frage">
-                    Frage-Text <span class="field-required">*</span>
+            <div class="zf-field">
+                <label class="zf-label" for="frage">
+                    Frage-Text <span class="zf-req">*</span>
                 </label>
-                <textarea id="frage" name="frage" class="field-textarea" required>{{ old('frage', $question->frage) }}</textarea>
-                @error('frage')<span class="field-error">{{ $message }}</span>@enderror
+                <textarea id="frage" name="frage" class="zf-textarea" required>{{ old('frage', $question->frage) }}</textarea>
+                @error('frage')<span class="zf-field-error">{{ $message }}</span>@enderror
             </div>
         </div>
 
@@ -223,16 +153,18 @@
             @include('admin.extra-questions.partials.form-image-select', ['question' => $question])
         @endif
 
-        <div class="form-actions">
+        <div class="zf-form-actions">
             <a href="{{ route('admin.extra-questions.index') }}" class="btn-ghost">Abbrechen</a>
-            <button type="submit" class="btn-primary">Änderungen speichern</button>
+            <button type="submit" class="btn-primary">
+                <i class="bi bi-check2"></i> Änderungen speichern
+            </button>
         </div>
     </form>
 
-    <div class="glass-error" style="padding: 1.25rem; margin-top: 1.5rem; display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap;">
+    <div class="zf-danger-zone">
         <div>
             <strong>Zusatz-Frage löschen</strong>
-            <p class="hint" style="margin: 0.25rem 0 0 0;">Unwiderruflich. Zugehörige Bilder werden aus dem Storage entfernt.</p>
+            <p class="zf-danger-zone__meta">Unwiderruflich. Zugehörige Bilder werden aus dem Storage entfernt.</p>
         </div>
         <form method="POST" action="{{ route('admin.extra-questions.destroy', $question) }}"
               onsubmit="return confirm('Zusatz-Frage #{{ $question->id }} wirklich löschen?')" style="margin: 0;">

--- a/resources/views/admin/extra-questions/index.blade.php
+++ b/resources/views/admin/extra-questions/index.blade.php
@@ -3,102 +3,205 @@
 @section('description', 'Verwalte optionale Zusatz-Fragen (Zuordnung, Bild benennen, Bild auswählen).')
 
 @push('styles')
+@include('admin.extra-questions.partials._styles')
 <style>
-    .typ-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.35rem;
-        padding: 0.2rem 0.6rem;
-        font-size: 0.7rem;
-        font-weight: 700;
-        letter-spacing: 0.03em;
-        text-transform: uppercase;
+    .zf-empty {
+        padding: 3.25rem 1.5rem;
+        text-align: center;
+    }
+    .zf-empty__icon {
+        width: 64px;
+        height: 64px;
+        margin: 0 auto 1rem;
         border-radius: 999px;
-        border: 1px solid rgba(255,255,255,0.12);
-        background: rgba(255,255,255,0.04);
-        color: var(--text-secondary);
-    }
-    .typ-badge.typ-matching { color: #a5b4fc; border-color: rgba(165,180,252,0.35); background: rgba(99,102,241,0.08); }
-    .typ-badge.typ-image_name { color: #6ee7b7; border-color: rgba(110,231,183,0.35); background: rgba(16,185,129,0.08); }
-    .typ-badge.typ-image_select { color: #fcd34d; border-color: rgba(252,211,77,0.35); background: rgba(245,158,11,0.08); }
-
-    .lernabschnitt-badge {
-        display: inline-block;
-        padding: 0.2rem 0.55rem;
-        font-size: 0.72rem;
-        font-weight: 700;
-        border-radius: 0.375rem;
-        background: linear-gradient(135deg, var(--thw-blue-start) 0%, var(--thw-blue-end) 100%);
-        color: #fff;
-        letter-spacing: 0.02em;
-    }
-
-    .eq-row {
+        background: rgba(0, 51, 127, 0.08);
         display: grid;
-        grid-template-columns: auto auto 1fr auto;
-        gap: 1rem;
-        align-items: center;
-        padding: 0.9rem 1rem;
-        border-bottom: 1px solid rgba(255,255,255,0.05);
-        transition: background 0.15s;
+        place-items: center;
+        color: var(--thw-blue);
+        font-size: 1.75rem;
     }
-    .eq-row:last-child { border-bottom: none; }
-    .eq-row:hover { background: rgba(255,255,255,0.02); }
+    html:not(.light-mode) .zf-empty__icon {
+        background: rgba(91, 154, 255, 0.12);
+        color: #5b9aff;
+    }
+    .zf-empty__text {
+        font-size: 0.9375rem;
+        color: var(--text-secondary);
+        margin: 0 0 1.25rem;
+    }
 
-    .eq-frage {
+    .zf-section-group { padding: 0.25rem 0.75rem 0.75rem; }
+    .zf-section-group + .zf-section-group { margin-top: 1.25rem; }
+    .zf-section-group__head {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.875rem 0.5rem;
+        border-bottom: 1px solid rgba(0, 51, 127, 0.06);
+        margin-bottom: 0.25rem;
+    }
+    html:not(.light-mode) .zf-section-group__head { border-bottom-color: rgba(255, 255, 255, 0.06); }
+    .zf-section-group__title {
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        font-size: 0.75rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--thw-blue);
+    }
+    html:not(.light-mode) .zf-section-group__title { color: #5b9aff; }
+    .zf-section-group__count {
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        font-size: 0.6875rem;
+        font-weight: 600;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+    }
+
+    .zf-list-row {
+        display: grid;
+        grid-template-columns: 2.5rem 1fr auto auto auto;
+        align-items: center;
+        gap: 1rem;
+        padding: 0.875rem 0.75rem;
+        border-radius: 0.625rem;
+        transition: background 0.15s ease;
+    }
+    .zf-list-row + .zf-list-row { border-top: 1px solid rgba(0, 51, 127, 0.06); }
+    html:not(.light-mode) .zf-list-row + .zf-list-row { border-top-color: rgba(255, 255, 255, 0.05); }
+    .zf-list-row:hover { background: rgba(0, 51, 127, 0.04); }
+    html:not(.light-mode) .zf-list-row:hover { background: rgba(91, 154, 255, 0.06); }
+    .zf-list-num {
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--text-muted);
+    }
+    .zf-list-title {
+        font-size: 0.9375rem;
+        font-weight: 600;
         color: var(--text-primary);
-        font-size: 0.92rem;
-        line-height: 1.45;
         display: -webkit-box;
         -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;
         overflow: hidden;
+        line-height: 1.4;
+    }
+    .zf-list-meta {
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        font-size: 0.6875rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--text-muted);
+        margin-top: 0.25rem;
     }
 
-    .eq-actions {
+    .zf-type-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.325rem;
+        padding: 0.2rem 0.55rem;
+        border-radius: 999px;
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        font-size: 0.625rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        white-space: nowrap;
+    }
+    .zf-type-chip--matching     { background: rgba(0, 51, 127, 0.10);   color: var(--thw-blue); }
+    html:not(.light-mode) .zf-type-chip--matching { background: rgba(91, 154, 255, 0.14); color: #5b9aff; }
+    .zf-type-chip--image_name   { background: rgba(22, 163, 74, 0.12);  color: #16a34a; }
+    .zf-type-chip--image_select { background: rgba(139, 92, 246, 0.14); color: #8b5cf6; }
+
+    .zf-row-actions {
         display: flex;
-        gap: 0.4rem;
+        gap: 0.35rem;
         align-items: center;
     }
-
-    .eq-empty {
-        text-align: center;
-        padding: 3rem 1rem;
+    .zf-icon-btn {
+        width: 2rem;
+        height: 2rem;
+        border-radius: 0.5rem;
+        background: transparent;
+        border: 1px solid rgba(0, 51, 127, 0.10);
         color: var(--text-muted);
+        cursor: pointer;
+        display: grid;
+        place-items: center;
+        font-size: 0.85rem;
+        text-decoration: none;
+        transition: all 0.15s ease;
+    }
+    html:not(.light-mode) .zf-icon-btn { border-color: rgba(255, 255, 255, 0.10); }
+    .zf-icon-btn:hover {
+        border-color: var(--thw-blue);
+        color: var(--thw-blue);
+        background: rgba(0, 51, 127, 0.04);
+    }
+    html:not(.light-mode) .zf-icon-btn:hover {
+        border-color: #5b9aff;
+        color: #5b9aff;
+        background: rgba(91, 154, 255, 0.08);
+    }
+    .zf-icon-btn--danger:hover {
+        border-color: #ef4444;
+        color: #ef4444;
+        background: rgba(239, 68, 68, 0.06);
     }
 
-    .section-group + .section-group { margin-top: 1.5rem; }
-
     @media (max-width: 640px) {
-        .eq-row { grid-template-columns: 1fr; }
-        .eq-actions { justify-content: flex-start; }
+        .zf-list-row { grid-template-columns: 1fr; gap: 0.5rem; }
+        .zf-list-num { display: none; }
+        .zf-row-actions { justify-content: flex-start; }
     }
 </style>
 @endpush
 
 @section('content')
-<div class="dashboard-container">
-    <header class="dashboard-header">
-        <h1 class="page-title">Zusatz-<span>Fragen</span></h1>
-        <p class="page-subtitle">Optionale Lern-Ergänzung: Zuordnung, Bild benennen, Bild auswählen</p>
-    </header>
+@php
+    $total = $questions->count();
+    $byTyp = $questions->groupBy('typ');
+    $countMatching    = $byTyp->get('matching', collect())->count();
+    $countImageName   = $byTyp->get('image_name', collect())->count();
+    $countImageSelect = $byTyp->get('image_select', collect())->count();
+    $grouped = $questions->groupBy('lernabschnitt');
+
+    $typLabels = [
+        'matching'     => 'Zuordnung',
+        'image_name'   => 'Bild benennen',
+        'image_select' => 'Bild auswählen',
+    ];
+    $typIcons = [
+        'matching'     => 'bi-diagram-3-fill',
+        'image_name'   => 'bi-image-fill',
+        'image_select' => 'bi-grid-3x3-gap-fill',
+    ];
+@endphp
+
+<div class="dash-container">
+    <div class="zf-page-title">
+        <div class="zf-page-title__eyebrow">Admin · Fragen</div>
+        <h1 class="zf-page-title__h1">Zusatz-Fragen</h1>
+        <div class="zf-page-title__sub">Optionale Lern-Ergänzung: Zuordnung, Bild benennen, Bild auswählen</div>
+    </div>
 
     @if(session('success'))
-        <div class="glass-success" style="padding: 1.25rem; margin-bottom: 1.5rem; display: flex; gap: 1rem; align-items: flex-start;">
-            <i class="bi bi-check-circle" style="font-size: 1.25rem; flex-shrink: 0;"></i>
-            <div>
-                <strong>Erfolg!</strong>
-                <p style="margin: 0.25rem 0 0 0;">{{ session('success') }}</p>
-            </div>
+        <div class="zf-alert zf-alert--success">
+            <i class="bi bi-check-circle-fill"></i>
+            <div><strong>Erfolg!</strong>{{ session('success') }}</div>
         </div>
     @endif
 
     @if($errors->any())
-        <div class="glass-error" style="padding: 1.25rem; margin-bottom: 1.5rem; display: flex; gap: 1rem; align-items: flex-start;">
-            <i class="bi bi-x-circle" style="font-size: 1.25rem; flex-shrink: 0;"></i>
+        <div class="zf-alert zf-alert--error">
+            <i class="bi bi-x-circle-fill"></i>
             <div>
                 <strong>Fehler!</strong>
-                <ul style="margin: 0.25rem 0 0 0; padding-left: 1.25rem;">
+                <ul>
                     @foreach($errors->all() as $error)
                         <li>{{ $error }}</li>
                     @endforeach
@@ -107,123 +210,90 @@
         </div>
     @endif
 
-    @php
-        $total = $questions->count();
-        $byTyp = $questions->groupBy('typ');
-        $countMatching = $byTyp->get('matching', collect())->count();
-        $countImageName = $byTyp->get('image_name', collect())->count();
-        $countImageSelect = $byTyp->get('image_select', collect())->count();
-        $grouped = $questions->groupBy('lernabschnitt');
-
-        $typLabels = [
-            'matching' => 'Zuordnung',
-            'image_name' => 'Bild benennen',
-            'image_select' => 'Bild auswählen',
-        ];
-    @endphp
-
-    <div class="stats-row">
-        <div class="stat-pill">
-            <span class="stat-pill-icon text-gold"><i class="bi bi-collection"></i></span>
-            <div>
-                <div class="stat-pill-value">{{ $total }}</div>
-                <div class="stat-pill-label">Gesamt</div>
-            </div>
+    <div class="zf-stat-pills">
+        <div class="zf-stat-pill">
+            <div class="zf-stat-pill__value">{{ $total }}</div>
+            <div class="zf-stat-pill__label">Gesamt</div>
         </div>
-        <div class="stat-pill">
-            <span class="stat-pill-icon text-thw-blue"><i class="bi bi-diagram-3"></i></span>
-            <div>
-                <div class="stat-pill-value">{{ $countMatching }}</div>
-                <div class="stat-pill-label">Zuordnung</div>
-            </div>
+        <div class="zf-stat-pill">
+            <div class="zf-stat-pill__value zf-stat-pill__value--blue">{{ $countMatching }}</div>
+            <div class="zf-stat-pill__label">Zuordnung</div>
         </div>
-        <div class="stat-pill">
-            <span class="stat-pill-icon text-success"><i class="bi bi-image"></i></span>
-            <div>
-                <div class="stat-pill-value">{{ $countImageName }}</div>
-                <div class="stat-pill-label">Bild benennen</div>
-            </div>
+        <div class="zf-stat-pill">
+            <div class="zf-stat-pill__value zf-stat-pill__value--ok">{{ $countImageName }}</div>
+            <div class="zf-stat-pill__label">Bild benennen</div>
         </div>
-        <div class="stat-pill">
-            <span class="stat-pill-icon text-gold"><i class="bi bi-grid-3x3-gap"></i></span>
-            <div>
-                <div class="stat-pill-value">{{ $countImageSelect }}</div>
-                <div class="stat-pill-label">Bild auswählen</div>
-            </div>
+        <div class="zf-stat-pill">
+            <div class="zf-stat-pill__value zf-stat-pill__value--warn">{{ $countImageSelect }}</div>
+            <div class="zf-stat-pill__label">Bild auswählen</div>
         </div>
     </div>
 
-    <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem; margin: 1.5rem 0 1rem;">
-        <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start);">
-            <h2 class="section-title">Alle Zusatz-Fragen</h2>
-        </div>
+    <div class="zf-action-row">
+        <span class="zf-section-label">
+            Alle Zusatz-Fragen{{ $total > 0 ? ' · '.$total : '' }}
+        </span>
         <a href="{{ route('admin.extra-questions.create') }}" class="btn-primary">
-            Neue Zusatz-Frage
+            <i class="bi bi-plus-lg"></i> Neue Zusatz-Frage
         </a>
     </div>
 
-    @if($total === 0)
-        <div class="glass eq-empty">
-            <div style="font-size: 3rem; margin-bottom: 1rem; opacity: 0.5;">
-                <i class="bi bi-collection"></i>
+    <div class="zf-form-card" style="padding: 0.75rem; overflow: hidden;">
+        @if($total === 0)
+            <div class="zf-empty">
+                <div class="zf-empty__icon"><i class="bi bi-inboxes"></i></div>
+                <p class="zf-empty__text">Noch keine Zusatz-Fragen vorhanden.</p>
+                <a href="{{ route('admin.extra-questions.create') }}" class="btn-primary">
+                    <i class="bi bi-plus-lg"></i> Erste Zusatz-Frage anlegen
+                </a>
             </div>
-            <p style="margin: 0 0 1rem;">Noch keine Zusatz-Fragen vorhanden.</p>
-            <a href="{{ route('admin.extra-questions.create') }}" class="btn-primary">
-                Erste Zusatz-Frage anlegen
-            </a>
-        </div>
-    @else
-        <div class="bento-grid">
+        @else
             @foreach($grouped as $lernabschnitt => $group)
-                <div class="glass-tl bento-wide section-group" style="padding: 1.25rem 1.5rem;">
-                    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem; gap: 0.75rem; flex-wrap: wrap;">
-                        <h3 style="font-size: 1rem; font-weight: 700; margin: 0; display: flex; align-items: center; gap: 0.6rem;">
-                            <span class="lernabschnitt-badge">{{ $lernabschnitt }}</span>
-                            <span style="color: var(--text-muted); font-weight: 500; font-size: 0.85rem;">
-                                {{ $group->count() }} {{ $group->count() === 1 ? 'Frage' : 'Fragen' }}
-                            </span>
-                        </h3>
+                <div class="zf-section-group">
+                    <div class="zf-section-group__head">
+                        <span class="zf-section-group__title">Lernabschnitt {{ $lernabschnitt }}</span>
+                        <span class="zf-section-group__count">
+                            {{ $group->count() }} {{ $group->count() === 1 ? 'Frage' : 'Fragen' }}
+                        </span>
                     </div>
-
-                    <div>
-                        @foreach($group as $q)
-                            <div class="eq-row">
-                                <span class="typ-badge typ-{{ $q->typ }}">
+                    @foreach($group as $idx => $q)
+                        <div class="zf-list-row">
+                            <div class="zf-list-num">#{{ str_pad($q->id, 2, '0', STR_PAD_LEFT) }}</div>
+                            <div>
+                                <div class="zf-list-title">{{ $q->frage }}</div>
+                                <div class="zf-list-meta">
                                     @if($q->typ === 'matching')
-                                        <i class="bi bi-diagram-3"></i>
+                                        {{ $q->matchCategories->count() }} Kategorien · {{ $q->matchItems->count() }} Items
                                     @elseif($q->typ === 'image_name')
-                                        <i class="bi bi-image"></i>
-                                    @else
-                                        <i class="bi bi-grid-3x3-gap"></i>
+                                        {{ $q->options->count() }} Antworten
+                                    @elseif($q->typ === 'image_select')
+                                        {{ $q->options->count() }} Bilder
                                     @endif
-                                    {{ $typLabels[$q->typ] ?? $q->typ }}
-                                </span>
-
-                                <span style="color: var(--text-muted); font-size: 0.78rem; font-variant-numeric: tabular-nums;">
-                                    #{{ $q->id }}
-                                </span>
-
-                                <div class="eq-frage">{{ $q->frage }}</div>
-
-                                <div class="eq-actions">
-                                    <a href="{{ route('admin.extra-questions.edit', $q) }}" class="btn-secondary" style="padding: 0.4rem 0.75rem; font-size: 0.8rem;">
-                                        Bearbeiten
-                                    </a>
-                                    <form method="POST" action="{{ route('admin.extra-questions.destroy', $q) }}"
-                                          onsubmit="return confirm('Zusatz-Frage wirklich löschen?')" style="margin: 0;">
-                                        @csrf
-                                        @method('DELETE')
-                                        <button type="submit" class="btn-ghost" style="padding: 0.4rem 0.65rem; color: var(--error); font-size: 0.8rem;">
-                                            <i class="bi bi-trash"></i>
-                                        </button>
-                                    </form>
                                 </div>
                             </div>
-                        @endforeach
-                    </div>
+                            <span class="zf-type-chip zf-type-chip--{{ $q->typ }}">
+                                <i class="bi {{ $typIcons[$q->typ] ?? 'bi-question' }}"></i>
+                                {{ $typLabels[$q->typ] ?? $q->typ }}
+                            </span>
+                            <div class="zf-row-actions">
+                                <a href="{{ route('admin.extra-questions.edit', $q) }}" class="zf-icon-btn" title="Bearbeiten">
+                                    <i class="bi bi-pencil"></i>
+                                </a>
+                                <form method="POST" action="{{ route('admin.extra-questions.destroy', $q) }}"
+                                      onsubmit="return confirm('Zusatz-Frage wirklich löschen?')" style="margin: 0;">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="zf-icon-btn zf-icon-btn--danger" title="Löschen">
+                                        <i class="bi bi-trash"></i>
+                                    </button>
+                                </form>
+                            </div>
+                            <i class="bi bi-chevron-right" style="color: var(--text-muted); font-size: 0.85rem;"></i>
+                        </div>
+                    @endforeach
                 </div>
             @endforeach
-        </div>
-    @endif
+        @endif
+    </div>
 </div>
 @endsection

--- a/resources/views/admin/extra-questions/partials/_styles.blade.php
+++ b/resources/views/admin/extra-questions/partials/_styles.blade.php
@@ -1,0 +1,564 @@
+{{-- Shared Zusatz-Fragen styles (aligned with Claude Design mockup).
+     Scoped with .zf-* prefix so the global design system stays intact. --}}
+<style>
+    .zf-page-title { margin-bottom: 1.5rem; }
+    .zf-page-title__eyebrow {
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        font-size: 0.75rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--text-muted);
+        margin-bottom: 0.5rem;
+    }
+    .zf-page-title__h1 {
+        font-family: var(--font-sans, 'Figtree', sans-serif);
+        font-weight: 800;
+        font-size: 2rem;
+        line-height: 1.15;
+        letter-spacing: -0.015em;
+        color: #5b9aff;
+        margin: 0 0 0.25rem;
+    }
+    html.light-mode .zf-page-title__h1,
+    .light-mode .zf-page-title__h1 { color: var(--thw-blue); }
+    .zf-page-title__sub {
+        font-size: 1rem;
+        color: var(--text-secondary);
+        margin: 0;
+    }
+
+    .zf-section-label {
+        display: block;
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--text-muted);
+    }
+
+    .zf-stat-pills {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 0.75rem;
+        width: 100%;
+        margin: 1.5rem 0 1.75rem;
+    }
+    @media (max-width: 768px) { .zf-stat-pills { grid-template-columns: repeat(2, 1fr); } }
+    .zf-stat-pill {
+        background: var(--bg-elevated);
+        border: 1px solid rgba(0, 51, 127, 0.10);
+        border-radius: 0.75rem;
+        padding: 0.875rem 1rem;
+        text-align: center;
+    }
+    html.light-mode .zf-stat-pill,
+    .light-mode .zf-stat-pill {
+        background: #ffffff;
+        border-color: rgba(0, 51, 127, 0.06);
+        box-shadow: 0 1px 3px rgba(0, 51, 127, 0.04);
+    }
+    .zf-stat-pill__value {
+        font-family: var(--font-sans, 'Figtree', sans-serif);
+        font-weight: 800;
+        font-size: 1.75rem;
+        line-height: 1.1;
+        letter-spacing: -0.015em;
+        color: var(--text-primary);
+        margin-bottom: 0.25rem;
+    }
+    .zf-stat-pill__value--blue  { color: var(--thw-blue); }
+    html:not(.light-mode) .zf-stat-pill__value--blue { color: #5b9aff; }
+    .zf-stat-pill__value--ok    { color: #16a34a; }
+    .zf-stat-pill__value--warn  { color: #d97706; }
+    .zf-stat-pill__label {
+        font-size: 0.75rem;
+        font-weight: 500;
+        color: var(--text-muted);
+    }
+
+    .zf-action-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+    }
+
+    .zf-back-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.35rem 0.6rem;
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--text-secondary);
+        background: transparent;
+        border: 1px solid transparent;
+        border-radius: 0.5rem;
+        text-decoration: none;
+        transition: all 0.15s ease;
+    }
+    .zf-back-btn:hover {
+        color: var(--thw-blue);
+        background: rgba(0, 51, 127, 0.06);
+    }
+    html:not(.light-mode) .zf-back-btn:hover { color: #5b9aff; background: rgba(91, 154, 255, 0.08); }
+
+    .zf-form-card {
+        padding: 1.5rem;
+        border-radius: 1rem;
+        background: var(--bg-elevated);
+        border: 1px solid rgba(0, 51, 127, 0.08);
+        box-shadow: 0 1px 3px rgba(15, 23, 42, 0.04), 0 2px 12px rgba(0, 51, 127, 0.06);
+    }
+    html:not(.light-mode) .zf-form-card {
+        background: rgba(255, 255, 255, 0.04);
+        border-color: rgba(255, 255, 255, 0.08);
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+    }
+    .zf-form-card + .zf-form-card { margin-top: 1rem; }
+
+    .zf-form-card__label {
+        margin-bottom: 0.875rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+    }
+    .zf-form-card__label .zf-hint {
+        font-family: var(--font-sans, 'Figtree', sans-serif);
+        font-weight: 500;
+        letter-spacing: 0;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+    }
+
+    .zf-type-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.75rem;
+    }
+    @media (max-width: 768px) { .zf-type-grid { grid-template-columns: 1fr; } }
+    .zf-type-card {
+        position: relative;
+        text-align: left;
+        padding: 1.125rem 1rem 1rem;
+        border-radius: 0.875rem;
+        background: var(--bg-elevated);
+        border: 1.5px solid rgba(0, 51, 127, 0.10);
+        cursor: pointer;
+        transition: all 0.25s ease;
+        font-family: inherit;
+        display: flex;
+        flex-direction: column;
+        gap: 0.625rem;
+        color: inherit;
+    }
+    html:not(.light-mode) .zf-type-card {
+        background: rgba(255, 255, 255, 0.03);
+        border-color: rgba(255, 255, 255, 0.08);
+    }
+    .zf-type-card:hover {
+        border-color: rgba(0, 51, 127, 0.40);
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(0, 51, 127, 0.08);
+    }
+    .zf-type-card.is-selected {
+        border-color: var(--thw-blue);
+        background: rgba(0, 51, 127, 0.04);
+        box-shadow: 0 0 0 3px rgba(0, 51, 127, 0.12), 0 4px 12px rgba(0, 51, 127, 0.15);
+    }
+    html:not(.light-mode) .zf-type-card.is-selected {
+        border-color: #5b9aff;
+        background: rgba(91, 154, 255, 0.06);
+        box-shadow: 0 0 0 3px rgba(91, 154, 255, 0.18), 0 4px 12px rgba(0, 51, 127, 0.25);
+    }
+    .zf-type-card__icon {
+        width: 32px;
+        height: 32px;
+        border-radius: 0.5rem;
+        display: grid;
+        place-items: center;
+        background: rgba(0, 51, 127, 0.10);
+        color: var(--thw-blue);
+        font-size: 1rem;
+    }
+    html:not(.light-mode) .zf-type-card__icon {
+        background: rgba(91, 154, 255, 0.15);
+        color: #5b9aff;
+    }
+    .zf-type-card__title {
+        font-weight: 700;
+        font-size: 0.9375rem;
+        color: var(--text-primary);
+    }
+    .zf-type-card__desc {
+        font-size: 0.75rem;
+        line-height: 1.45;
+        color: var(--text-secondary);
+    }
+    .zf-type-card__check {
+        position: absolute;
+        top: 0.75rem;
+        right: 0.75rem;
+        width: 20px;
+        height: 20px;
+        border-radius: 999px;
+        background: var(--thw-blue);
+        color: #fff;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.65rem;
+    }
+    .zf-type-card.is-selected .zf-type-card__check { display: grid; place-items: center; }
+
+    .zf-field { margin-bottom: 1rem; }
+    .zf-field:last-child { margin-bottom: 0; }
+    .zf-label {
+        display: block;
+        font-size: 0.8125rem;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: 0.375rem;
+    }
+    .zf-label .zf-req { color: #ef4444; }
+    .zf-help {
+        display: block;
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        margin-top: 0.375rem;
+    }
+    .zf-input, .zf-textarea, .zf-select {
+        width: 100%;
+        padding: 0.625rem 0.875rem;
+        font-family: inherit;
+        font-size: 0.9375rem;
+        color: var(--text-primary);
+        background: var(--bg-elevated);
+        border: 1px solid rgba(0, 51, 127, 0.15);
+        border-radius: 0.5rem;
+        outline: none;
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+    html:not(.light-mode) .zf-input,
+    html:not(.light-mode) .zf-textarea,
+    html:not(.light-mode) .zf-select {
+        background: rgba(255, 255, 255, 0.04);
+        border-color: rgba(255, 255, 255, 0.12);
+    }
+    .zf-input:focus, .zf-textarea:focus, .zf-select:focus {
+        border-color: var(--thw-blue);
+        box-shadow: 0 0 0 3px rgba(0, 51, 127, 0.12);
+    }
+    html:not(.light-mode) .zf-input:focus,
+    html:not(.light-mode) .zf-textarea:focus,
+    html:not(.light-mode) .zf-select:focus {
+        border-color: #5b9aff;
+        box-shadow: 0 0 0 3px rgba(91, 154, 255, 0.18);
+    }
+    .zf-textarea { min-height: 92px; resize: vertical; line-height: 1.5; }
+    .zf-select { appearance: none; -webkit-appearance: none; background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%2300337F' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3e%3c/svg%3e"); background-repeat: no-repeat; background-position: right 0.75rem center; background-size: 1rem; padding-right: 2.25rem; }
+
+    .zf-option-row {
+        display: grid;
+        grid-template-columns: 1.75rem 1fr auto;
+        gap: 0.625rem;
+        align-items: center;
+        padding: 0.625rem 0;
+    }
+    .zf-option-row + .zf-option-row { border-top: 1px solid rgba(0, 51, 127, 0.06); }
+    html:not(.light-mode) .zf-option-row + .zf-option-row { border-top-color: rgba(255, 255, 255, 0.06); }
+    .zf-option-num {
+        width: 1.75rem;
+        height: 1.75rem;
+        border-radius: 0.5rem;
+        background: rgba(0, 51, 127, 0.08);
+        display: grid;
+        place-items: center;
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--thw-blue);
+    }
+    html:not(.light-mode) .zf-option-num {
+        background: rgba(91, 154, 255, 0.12);
+        color: #5b9aff;
+    }
+    .zf-option-body {
+        display: flex;
+        align-items: center;
+        gap: 0.625rem;
+        flex-wrap: wrap;
+        min-width: 0;
+    }
+    .zf-option-body > .zf-input { flex: 1 1 160px; }
+    .zf-option-remove {
+        width: 2rem;
+        height: 2rem;
+        border-radius: 0.5rem;
+        background: transparent;
+        border: 1px solid rgba(0, 51, 127, 0.10);
+        color: var(--text-muted);
+        cursor: pointer;
+        display: grid;
+        place-items: center;
+        transition: all 0.15s ease;
+    }
+    html:not(.light-mode) .zf-option-remove { border-color: rgba(255, 255, 255, 0.12); }
+    .zf-option-remove:hover {
+        border-color: #ef4444;
+        color: #ef4444;
+        background: rgba(239, 68, 68, 0.06);
+    }
+    .zf-option-remove:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    .zf-add-row {
+        display: flex;
+        justify-content: center;
+        padding: 0.75rem 0 0;
+        margin-top: 0.5rem;
+        border-top: 1px dashed rgba(0, 51, 127, 0.12);
+    }
+    html:not(.light-mode) .zf-add-row { border-top-color: rgba(255, 255, 255, 0.10); }
+    .zf-add-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.5rem 0.875rem;
+        border-radius: 0.5rem;
+        border: 1px dashed rgba(0, 51, 127, 0.2);
+        background: transparent;
+        color: var(--thw-blue);
+        font-weight: 600;
+        font-size: 0.8125rem;
+        cursor: pointer;
+        font-family: inherit;
+        transition: all 0.15s ease;
+    }
+    html:not(.light-mode) .zf-add-btn {
+        color: #5b9aff;
+        border-color: rgba(91, 154, 255, 0.25);
+    }
+    .zf-add-btn:hover:not(:disabled) {
+        background: rgba(0, 51, 127, 0.04);
+        border-color: var(--thw-blue);
+        border-style: solid;
+    }
+    html:not(.light-mode) .zf-add-btn:hover:not(:disabled) {
+        background: rgba(91, 154, 255, 0.08);
+        border-color: #5b9aff;
+    }
+    .zf-add-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+    .zf-pair {
+        padding: 0.875rem;
+        border-radius: 0.75rem;
+        background: rgba(0, 51, 127, 0.025);
+        border: 1px solid rgba(0, 51, 127, 0.06);
+        margin-bottom: 0.625rem;
+        position: relative;
+    }
+    html:not(.light-mode) .zf-pair {
+        background: rgba(255, 255, 255, 0.02);
+        border-color: rgba(255, 255, 255, 0.06);
+    }
+    .zf-pair__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 0.625rem;
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        font-size: 0.6875rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-muted);
+    }
+    .zf-pair__arrow {
+        display: grid;
+        place-items: center;
+        padding: 0.4rem 0;
+        color: var(--thw-blue);
+        font-size: 0.875rem;
+    }
+    html:not(.light-mode) .zf-pair__arrow { color: #5b9aff; }
+    .zf-pair > .zf-input + .zf-pair__arrow { margin-top: 0.25rem; }
+
+    .zf-upload {
+        padding: 1.5rem 1.25rem;
+        border-radius: 0.75rem;
+        background: rgba(0, 51, 127, 0.025);
+        border: 2px dashed rgba(0, 51, 127, 0.18);
+        text-align: center;
+        cursor: pointer;
+        transition: all 0.15s ease;
+    }
+    html:not(.light-mode) .zf-upload {
+        background: rgba(255, 255, 255, 0.02);
+        border-color: rgba(255, 255, 255, 0.12);
+    }
+    .zf-upload:hover {
+        border-color: var(--thw-blue);
+        background: rgba(0, 51, 127, 0.04);
+    }
+    html:not(.light-mode) .zf-upload:hover {
+        border-color: #5b9aff;
+        background: rgba(91, 154, 255, 0.06);
+    }
+    .zf-upload__icon {
+        font-size: 1.5rem;
+        color: var(--thw-blue);
+        margin-bottom: 0.5rem;
+    }
+    html:not(.light-mode) .zf-upload__icon { color: #5b9aff; }
+    .zf-upload__title {
+        font-weight: 600;
+        font-size: 0.875rem;
+        color: var(--text-primary);
+        margin-bottom: 0.25rem;
+    }
+    .zf-upload__sub {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+    }
+    .zf-upload input[type="file"] {
+        position: absolute;
+        width: 0.1px;
+        height: 0.1px;
+        opacity: 0;
+        overflow: hidden;
+        z-index: -1;
+    }
+
+    .zf-image-preview {
+        margin-top: 0.75rem;
+        max-width: 320px;
+        border-radius: 0.5rem;
+        overflow: hidden;
+        border: 1px solid rgba(0, 51, 127, 0.10);
+    }
+    html:not(.light-mode) .zf-image-preview { border-color: rgba(255, 255, 255, 0.10); }
+    .zf-image-preview img { width: 100%; height: auto; display: block; }
+
+    .zf-image-tile {
+        display: grid;
+        grid-template-columns: 120px 1fr;
+        gap: 0.75rem;
+        padding: 0.875rem;
+        border-radius: 0.75rem;
+        background: rgba(0, 51, 127, 0.025);
+        border: 1px solid rgba(0, 51, 127, 0.06);
+        margin-bottom: 0.625rem;
+    }
+    html:not(.light-mode) .zf-image-tile {
+        background: rgba(255, 255, 255, 0.02);
+        border-color: rgba(255, 255, 255, 0.06);
+    }
+    .zf-image-tile__head {
+        grid-column: 1 / -1;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+        margin-bottom: 0.25rem;
+    }
+    .zf-image-tile__num {
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        font-size: 0.6875rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-muted);
+    }
+    .zf-image-tile__thumb {
+        width: 120px;
+        height: 90px;
+        border-radius: 0.5rem;
+        overflow: hidden;
+        background: rgba(0, 51, 127, 0.05);
+        display: grid;
+        place-items: center;
+        color: var(--thw-blue);
+        border: 1px dashed rgba(0, 51, 127, 0.18);
+    }
+    html:not(.light-mode) .zf-image-tile__thumb {
+        background: rgba(91, 154, 255, 0.08);
+        color: #5b9aff;
+        border-color: rgba(255, 255, 255, 0.10);
+    }
+    .zf-image-tile__thumb img { width: 100%; height: 100%; object-fit: cover; }
+    .zf-image-tile__body {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        min-width: 0;
+    }
+
+    .zf-correct-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        cursor: pointer;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--text-muted);
+        user-select: none;
+    }
+    .zf-correct-toggle input { accent-color: #16a34a; }
+    .zf-correct-toggle.is-correct { color: #16a34a; }
+
+    .zf-form-actions {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        margin-top: 1.5rem;
+        padding-top: 0.25rem;
+        flex-wrap: wrap;
+    }
+
+    .zf-alert {
+        padding: 0.875rem 1rem;
+        border-radius: 0.75rem;
+        display: flex;
+        gap: 0.75rem;
+        align-items: flex-start;
+        font-size: 0.875rem;
+        margin-bottom: 1rem;
+    }
+    .zf-alert--error {
+        background: rgba(239, 68, 68, 0.08);
+        border: 1px solid rgba(239, 68, 68, 0.22);
+        color: #ef4444;
+    }
+    .zf-alert--success {
+        background: rgba(22, 163, 74, 0.08);
+        border: 1px solid rgba(22, 163, 74, 0.22);
+        color: #16a34a;
+    }
+    .zf-alert--info {
+        background: rgba(0, 51, 127, 0.05);
+        border: 1px solid rgba(0, 51, 127, 0.15);
+        color: var(--thw-blue);
+    }
+    html:not(.light-mode) .zf-alert--info {
+        background: rgba(91, 154, 255, 0.08);
+        border-color: rgba(91, 154, 255, 0.20);
+        color: #5b9aff;
+    }
+    .zf-alert strong { display: block; color: inherit; margin-bottom: 0.15rem; }
+    .zf-alert ul { margin: 0.15rem 0 0 1.25rem; padding: 0; }
+
+    .zf-field-error {
+        display: block;
+        margin-top: 0.35rem;
+        color: #ef4444;
+        font-size: 0.8rem;
+    }
+
+    [x-cloak] { display: none !important; }
+</style>

--- a/resources/views/admin/extra-questions/partials/form-image-name.blade.php
+++ b/resources/views/admin/extra-questions/partials/form-image-name.blade.php
@@ -27,34 +27,42 @@
 @endphp
 
 {{-- Frage-Bild --}}
-<div class="glass" style="padding: 1.5rem; margin-bottom: 1.25rem;">
-    <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start); margin-bottom: 1rem;">
-        <h2 class="section-title" style="font-size: 1.05rem;">Frage-Bild</h2>
+<div class="zf-form-card" x-data="{
+    previewUrl: null,
+    hasFile: false,
+    onPick(ev) {
+        const f = ev.target.files[0];
+        this.previewUrl = f ? URL.createObjectURL(f) : null;
+        this.hasFile = !!f;
+    }
+}">
+    <div class="zf-form-card__label">
+        <span class="zf-section-label">Frage-Bild</span>
     </div>
 
     @if($existingImage)
-        <div class="hint" style="margin-bottom: 0.5rem;">Aktuelles Bild (wird bei neuem Upload ersetzt):</div>
-        <div class="image-preview" style="margin-bottom: 0.75rem;">
+        <div class="zf-help" style="margin-bottom: 0.5rem;">Aktuelles Bild (wird bei neuem Upload ersetzt):</div>
+        <div class="zf-image-preview" style="margin-bottom: 0.75rem;">
             <img src="{{ $existingImage }}" alt="Aktuelles Frage-Bild">
         </div>
     @endif
 
-    <div x-data="{ previewUrl: null, onPick(ev) { const f = ev.target.files[0]; this.previewUrl = f ? URL.createObjectURL(f) : null; } }">
-        <div class="file-field">
-            <input type="file" name="image" accept="image/jpeg,image/png,image/webp"
-                   @change="onPick($event)"
-                   {{ $existingImage ? '' : 'required' }}>
+    <label class="zf-upload" style="display: block; position: relative;">
+        <input type="file" name="image" accept="image/jpeg,image/png,image/webp"
+               @change="onPick($event)"
+               {{ $existingImage ? '' : 'required' }}>
+        <div class="zf-upload__icon"><i class="bi bi-cloud-arrow-up-fill"></i></div>
+        <div class="zf-upload__title" x-text="hasFile ? 'Anderes Bild wählen' : 'Bild hochladen'">Bild hochladen</div>
+        <div class="zf-upload__sub">JPG, PNG oder WebP · max. 5 MB</div>
+    </label>
+
+    <template x-if="previewUrl">
+        <div class="zf-image-preview">
+            <img :src="previewUrl" alt="Vorschau">
         </div>
-        <p class="hint">JPG, PNG oder WebP. Max. 5 MB.</p>
+    </template>
 
-        <template x-if="previewUrl">
-            <div class="image-preview">
-                <img :src="previewUrl" alt="Vorschau">
-            </div>
-        </template>
-
-        @error('image')<span class="field-error">{{ $message }}</span>@enderror
-    </div>
+    @error('image')<span class="zf-field-error">{{ $message }}</span>@enderror
 </div>
 
 {{-- Text-Optionen --}}
@@ -63,43 +71,42 @@
     addOption() { if (this.options.length < 6) this.options.push({ text: '', is_correct: false }); },
     removeOption(i) { if (this.options.length > 2) this.options.splice(i, 1); },
 }">
-    <div class="glass" style="padding: 1.5rem; margin-bottom: 1.25rem;">
-        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; gap: 1rem; flex-wrap: wrap;">
-            <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start);">
-                <h2 class="section-title" style="font-size: 1.05rem;">Antwort-Optionen</h2>
-            </div>
-            <span class="hint" x-text="`${options.length} / 6 (min. 2, mind. 1 richtig)`"></span>
+    <div class="zf-form-card">
+        <div class="zf-form-card__label">
+            <span class="zf-section-label">Antwort-Optionen</span>
+            <span class="zf-hint" x-text="`${options.length} / 6 · mind. 1 richtig`"></span>
         </div>
 
         <template x-for="(opt, i) in options" :key="i">
-            <div class="dyn-row">
-                <span class="dyn-index" x-text="i + 1"></span>
-                <div class="dyn-body">
-                    <input type="text" class="field-input"
-                           :name="`options[${i}][text]`"
-                           x-model="opt.text"
-                           placeholder="Antwort-Text" required>
-                    <label class="checkbox-inline">
-                        {{-- Hidden-Value-Trick: stellt sicher, dass is_correct immer mit 0 oder 1 übermittelt wird --}}
+            <div class="zf-option-row">
+                <div class="zf-option-num" x-text="String.fromCharCode(65 + i)"></div>
+                <div class="zf-option-body">
+                    <label class="zf-correct-toggle" :class="{ 'is-correct': opt.is_correct }">
                         <input type="hidden" :name="`options[${i}][is_correct]`" :value="opt.is_correct ? 1 : 0">
                         <input type="checkbox" x-model="opt.is_correct">
-                        <span>Richtige Antwort</span>
+                        <span>Richtig</span>
                     </label>
+                    <input type="text" class="zf-input"
+                           :name="`options[${i}][text]`"
+                           x-model="opt.text"
+                           :placeholder="`Antwort ${i + 1}`" required>
                 </div>
-                <button type="button" class="btn-icon-remove"
+                <button type="button" class="zf-option-remove"
                         @click="removeOption(i)"
                         :disabled="options.length <= 2"
                         title="Option entfernen">
-                    <i class="bi bi-x-lg"></i>
+                    <i class="bi bi-trash"></i>
                 </button>
             </div>
         </template>
 
-        <button type="button" class="btn-add-row"
-                @click="addOption()"
-                :disabled="options.length >= 6">
-            <i class="bi bi-plus-lg"></i> Option hinzufügen
-        </button>
-        @error('options')<span class="field-error">{{ $message }}</span>@enderror
+        <div class="zf-add-row">
+            <button type="button" class="zf-add-btn"
+                    @click="addOption()"
+                    :disabled="options.length >= 6">
+                <i class="bi bi-plus-lg"></i> Option hinzufügen
+            </button>
+        </div>
+        @error('options')<span class="zf-field-error">{{ $message }}</span>@enderror
     </div>
 </div>

--- a/resources/views/admin/extra-questions/partials/form-image-select.blade.php
+++ b/resources/views/admin/extra-questions/partials/form-image-select.blade.php
@@ -1,6 +1,6 @@
 @php
     $initialOptions = [];
-    $existingOptionImages = [];
+    $existingImageUrls = [];
 
     if (!empty(old('options'))) {
         foreach (old('options') as $o) {
@@ -13,7 +13,7 @@
             $initialOptions[] = [
                 'is_correct' => (bool) $opt->is_correct,
             ];
-            $existingOptionImages[] = $opt->image_path
+            $existingImageUrls[] = $opt->image_path
                 ? \Illuminate\Support\Facades\Storage::url($opt->image_path)
                 : null;
         }
@@ -29,16 +29,18 @@
 
 <div x-data="{
     options: @js($initialOptions),
+    existingImages: @js($existingImageUrls),
     previews: {},
     onPick(i, ev) {
         const f = ev.target.files[0];
         this.previews[i] = f ? URL.createObjectURL(f) : null;
     },
-    addOption() { if (this.options.length < 6) this.options.push({ is_correct: false }); },
+    addOption() {
+        if (this.options.length < 6) this.options.push({ is_correct: false });
+    },
     removeOption(i) {
         if (this.options.length > 2) {
             this.options.splice(i, 1);
-            // Preview-Keys nachziehen
             const np = {};
             this.options.forEach((_, idx) => {
                 if (this.previews[idx]) np[idx] = this.previews[idx];
@@ -46,83 +48,81 @@
             this.previews = np;
         }
     },
+    displayImage(i) {
+        if (this.previews[i]) return this.previews[i];
+        if (this.existingImages[i]) return this.existingImages[i];
+        return null;
+    },
 }">
-    <div class="glass" style="padding: 1.5rem; margin-bottom: 1.25rem;">
-        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; gap: 1rem; flex-wrap: wrap;">
-            <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start);">
-                <h2 class="section-title" style="font-size: 1.05rem;">Bild-Optionen</h2>
-            </div>
-            <span class="hint" x-text="`${options.length} / 6 (min. 2, mind. 1 richtig)`"></span>
+    <div class="zf-form-card">
+        <div class="zf-form-card__label">
+            <span class="zf-section-label">Bild-Optionen</span>
+            <span class="zf-hint" x-text="`${options.length} / 6 · mind. 1 richtig`"></span>
         </div>
 
         @if($isEdit)
-            <div class="glass-warning" style="padding: 0.85rem 1rem; margin-bottom: 1rem; font-size: 0.85rem;">
-                <strong>Hinweis:</strong> Beim Bearbeiten einer „Bild auswählen"-Frage müssen alle Bilder neu hochgeladen werden.
-                Die bisherigen Bilder werden zur Orientierung angezeigt.
+            <div class="zf-alert zf-alert--info">
+                <i class="bi bi-info-circle-fill"></i>
+                <div>
+                    <strong>Hinweis:</strong>
+                    Beim Bearbeiten einer „Bild auswählen"-Frage müssen alle Bilder neu hochgeladen werden.
+                    Die bisherigen Bilder werden zur Orientierung angezeigt.
+                </div>
             </div>
         @endif
 
         <template x-for="(opt, i) in options" :key="i">
-            <div class="dyn-row">
-                <span class="dyn-index" x-text="i + 1"></span>
-                <div class="dyn-body">
-                    <div class="file-field">
+            <div class="zf-image-tile">
+                <div class="zf-image-tile__head">
+                    <span class="zf-image-tile__num" x-text="'Option ' + String.fromCharCode(65 + i)"></span>
+                    <div style="display: flex; align-items: center; gap: 0.5rem;">
+                        <label class="zf-correct-toggle" :class="{ 'is-correct': opt.is_correct }">
+                            <input type="hidden" :name="`options[${i}][is_correct]`" :value="opt.is_correct ? 1 : 0">
+                            <input type="checkbox" x-model="opt.is_correct">
+                            <span>Richtig</span>
+                        </label>
+                        <button type="button" class="zf-option-remove"
+                                @click="removeOption(i)"
+                                :disabled="options.length <= 2"
+                                title="Option entfernen">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </div>
+                </div>
+
+                <div class="zf-image-tile__thumb">
+                    <template x-if="displayImage(i)">
+                        <img :src="displayImage(i)" alt="Bild-Vorschau">
+                    </template>
+                    <template x-if="!displayImage(i)">
+                        <i class="bi bi-cloud-arrow-up" style="font-size: 1.25rem;"></i>
+                    </template>
+                </div>
+
+                <div class="zf-image-tile__body">
+                    <label class="zf-upload" style="display: block; position: relative; padding: 0.75rem;">
                         <input type="file"
                                :name="`options[${i}][image]`"
                                accept="image/jpeg,image/png,image/webp"
                                @change="onPick(i, $event)"
                                required>
-                    </div>
-
-                    @if($isEdit)
-                        <template x-if="!previews[i]">
-                            <div>
-                                @foreach($existingOptionImages as $idx => $imgUrl)
-                                    <template x-if="i === {{ $idx }}">
-                                        <div>
-                                            @if($imgUrl)
-                                                <div class="hint">Bisheriges Bild:</div>
-                                                <div class="image-preview">
-                                                    <img src="{{ $imgUrl }}" alt="Bisheriges Option-Bild">
-                                                </div>
-                                            @endif
-                                        </div>
-                                    </template>
-                                @endforeach
-                            </div>
-                        </template>
-                    @endif
-
-                    <template x-if="previews[i]">
-                        <div>
-                            <div class="hint">Neue Vorschau:</div>
-                            <div class="image-preview">
-                                <img :src="previews[i]" alt="Vorschau">
-                            </div>
+                        <div class="zf-upload__title" style="margin-bottom: 0.15rem;">
+                            <i class="bi bi-cloud-arrow-up-fill"></i>
+                            <span x-text="previews[i] ? 'Anderes Bild wählen' : 'Bild wählen'">Bild wählen</span>
                         </div>
-                    </template>
-
-                    <label class="checkbox-inline">
-                        <input type="hidden" :name="`options[${i}][is_correct]`" :value="opt.is_correct ? 1 : 0">
-                        <input type="checkbox" x-model="opt.is_correct">
-                        <span>Richtige Antwort</span>
+                        <div class="zf-upload__sub">JPG, PNG oder WebP · max. 5 MB</div>
                     </label>
                 </div>
-                <button type="button" class="btn-icon-remove"
-                        @click="removeOption(i)"
-                        :disabled="options.length <= 2"
-                        title="Option entfernen">
-                    <i class="bi bi-x-lg"></i>
-                </button>
             </div>
         </template>
 
-        <button type="button" class="btn-add-row"
-                @click="addOption()"
-                :disabled="options.length >= 6">
-            <i class="bi bi-plus-lg"></i> Bild-Option hinzufügen
-        </button>
-        <p class="hint">JPG, PNG oder WebP. Max. 5 MB pro Bild.</p>
-        @error('options')<span class="field-error">{{ $message }}</span>@enderror
+        <div class="zf-add-row">
+            <button type="button" class="zf-add-btn"
+                    @click="addOption()"
+                    :disabled="options.length >= 6">
+                <i class="bi bi-plus-lg"></i> Bild-Option hinzufügen
+            </button>
+        </div>
+        @error('options')<span class="zf-field-error">{{ $message }}</span>@enderror
     </div>
 </div>

--- a/resources/views/admin/extra-questions/partials/form-matching.blade.php
+++ b/resources/views/admin/extra-questions/partials/form-matching.blade.php
@@ -1,5 +1,4 @@
 @php
-    // Vorbereitung initial-Daten (für Alpine)
     $initialCategories = [];
     $initialItems = [];
 
@@ -23,7 +22,6 @@
             ];
         }
     } elseif (isset($question) && $question && $question->matchItems->count()) {
-        // Mapping: correct_category_id -> index in matchCategories (sort_order)
         $catIdToIndex = [];
         foreach ($question->matchCategories as $i => $cat) {
             $catIdToIndex[$cat->id] = $i;
@@ -50,7 +48,6 @@
     removeCategory(i) {
         if (this.categories.length <= 2) return;
         this.categories.splice(i, 1);
-        // Items, die auf entfernte oder spätere Kategorie verweisen, anpassen
         this.items = this.items.map(it => {
             let idx = parseInt(it.category_index);
             if (idx === i) idx = 0;
@@ -62,80 +59,78 @@
     removeItem(i) { if (this.items.length > 3) this.items.splice(i, 1); },
 }">
     {{-- Kategorien --}}
-    <div class="glass" style="padding: 1.5rem; margin-bottom: 1.25rem;">
-        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; gap: 1rem; flex-wrap: wrap;">
-            <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start);">
-                <h2 class="section-title" style="font-size: 1.05rem;">Kategorien</h2>
-            </div>
-            <span class="hint" x-text="`${categories.length} / 5 (min. 2)`"></span>
+    <div class="zf-form-card">
+        <div class="zf-form-card__label">
+            <span class="zf-section-label">Kategorien</span>
+            <span class="zf-hint" x-text="`${categories.length} / 5 · min. 2`"></span>
         </div>
 
         <template x-for="(cat, i) in categories" :key="i">
-            <div class="dyn-row">
-                <span class="dyn-index" x-text="i + 1"></span>
-                <div class="dyn-body">
-                    <input type="text" class="field-input"
+            <div class="zf-option-row">
+                <div class="zf-option-num" x-text="i + 1"></div>
+                <div class="zf-option-body">
+                    <input type="text" class="zf-input"
                            :name="`categories[${i}][name]`"
                            x-model="cat.name"
                            :placeholder="`Kategorie ${i + 1}`" required>
                 </div>
-                <button type="button" class="btn-icon-remove"
+                <button type="button" class="zf-option-remove"
                         @click="removeCategory(i)"
                         :disabled="categories.length <= 2"
                         title="Kategorie entfernen">
-                    <i class="bi bi-x-lg"></i>
+                    <i class="bi bi-trash"></i>
                 </button>
             </div>
         </template>
 
-        <button type="button" class="btn-add-row"
-                @click="addCategory()"
-                :disabled="categories.length >= 5">
-            <i class="bi bi-plus-lg"></i> Kategorie hinzufügen
-        </button>
-        @error('categories')<span class="field-error">{{ $message }}</span>@enderror
+        <div class="zf-add-row">
+            <button type="button" class="zf-add-btn"
+                    @click="addCategory()"
+                    :disabled="categories.length >= 5">
+                <i class="bi bi-plus-lg"></i> Kategorie hinzufügen
+            </button>
+        </div>
+        @error('categories')<span class="zf-field-error">{{ $message }}</span>@enderror
     </div>
 
     {{-- Items --}}
-    <div class="glass" style="padding: 1.5rem; margin-bottom: 1.25rem;">
-        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; gap: 1rem; flex-wrap: wrap;">
-            <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start);">
-                <h2 class="section-title" style="font-size: 1.05rem;">Items &amp; Zuordnung</h2>
-            </div>
-            <span class="hint" x-text="`${items.length} / 10 (min. 3)`"></span>
+    <div class="zf-form-card">
+        <div class="zf-form-card__label">
+            <span class="zf-section-label">Items &amp; Zuordnung</span>
+            <span class="zf-hint" x-text="`${items.length} / 10 · min. 3`"></span>
         </div>
 
         <template x-for="(it, i) in items" :key="i">
-            <div class="dyn-row">
-                <span class="dyn-index" x-text="i + 1"></span>
-                <div class="dyn-body">
-                    <input type="text" class="field-input"
-                           :name="`items[${i}][text]`"
-                           x-model="it.text"
-                           placeholder="Item-Text (z.B. 'Personalführung')" required>
-                    <div>
-                        <label class="field-label" style="margin-bottom: 0.25rem;">Gehört zu:</label>
-                        <select class="field-input" :name="`items[${i}][category_index]`" x-model.number="it.category_index" required>
-                            <template x-for="(cat, ci) in categories" :key="ci">
-                                <option :value="ci" x-text="(ci + 1) + '. ' + (cat.name || 'Kategorie ' + (ci + 1))"></option>
-                            </template>
-                        </select>
-                    </div>
+            <div class="zf-pair">
+                <div class="zf-pair__head">
+                    <span x-text="`Item ${i + 1}`"></span>
+                    <button type="button" class="zf-option-remove"
+                            @click="removeItem(i)"
+                            :disabled="items.length <= 3"
+                            title="Item entfernen">
+                        <i class="bi bi-trash"></i>
+                    </button>
                 </div>
-                <button type="button" class="btn-icon-remove"
-                        @click="removeItem(i)"
-                        :disabled="items.length <= 3"
-                        title="Item entfernen">
-                    <i class="bi bi-x-lg"></i>
-                </button>
+                <input type="text" class="zf-input"
+                       :name="`items[${i}][text]`"
+                       x-model="it.text"
+                       placeholder="Item-Text (z.B. 'Mastwurf')" required>
+                <div class="zf-pair__arrow"><i class="bi bi-arrow-down"></i></div>
+                <select class="zf-select" :name="`items[${i}][category_index]`" x-model.number="it.category_index" required>
+                    <template x-for="(cat, ci) in categories" :key="ci">
+                        <option :value="ci" x-text="(ci + 1) + '. ' + (cat.name || 'Kategorie ' + (ci + 1))"></option>
+                    </template>
+                </select>
             </div>
         </template>
 
-        <button type="button" class="btn-add-row"
-                @click="addItem()"
-                :disabled="items.length >= 10">
-            <i class="bi bi-plus-lg"></i> Item hinzufügen
-        </button>
-        @error('items')<span class="field-error">{{ $message }}</span>@enderror
+        <div class="zf-add-row">
+            <button type="button" class="zf-add-btn"
+                    @click="addItem()"
+                    :disabled="items.length >= 10">
+                <i class="bi bi-plus-lg"></i> Item hinzufügen
+            </button>
+        </div>
+        @error('items')<span class="zf-field-error">{{ $message }}</span>@enderror
     </div>
 </div>


### PR DESCRIPTION
## Summary

Überarbeitet die beiden Admin-Seiten `/admin/extra-questions` und `/admin/extra-questions/create` gemäß der Claude-Design-Mockup-Vorgaben (inkl. `design-system-additions.md`). Edit-Seite + Form-Partials ziehen für Konsistenz mit.

## Was konkret geändert wurde

- **Seitentitel:** Produktecht als `.zf-page-title`-Block (Mono-Eyebrow + blauer H1 + grauer Sub) — **kein Gold-Span H1** mehr.
- **Stat-Pills:** Rechteckige Kacheln mit Zahl oben / Label unten (`zf-stat-pills`-Grid) — keine Icon-Kapseln.
- **Section-Header:** `.zf-section-label` (Mono uppercase) statt Gold-Left-Border-Header (der ist laut Design-Guide für Journey/Marketing reserviert).
- **Fragetyp-Picker:** Drei große Karten mit **blauem** Selected-State + Glow (vorher Gold).
- **Formular-Farben:** THW-Blau ist jetzt die Action-Farbe — Focus-Ringe, Upload-Hover, Add-Buttons, Pair-Arrow, Selected-Borders. Gold komplett aus Formularen raus.
- **Form-Karten:** Weiße `.zf-form-card` (bzw. dunkle Glass-Variante) mit `.zf-section-label` als Eyebrow.
- **Empty State:** Blaues Icon-Badge + Primary-Button "Erste Zusatz-Frage anlegen".
- **Edit-Seite + Partials:** Gleiche Sprache durchgezogen, damit Create/Edit konsistent sind. Typ ist auf der Edit-Seite als Chip gesperrt.

## Scoping

Alle neuen Klassen nutzen `.zf-*`-Prefix. Globale Patterns (`.page-title`, `.stat-pill` etc.) in `app.css` bleiben unangetastet — die beiden Seiten sind eine bewusste lokale Abweichung gemäß Mockup.

Theming: beide Seiten funktionieren in Dark und Light Mode (CSS-Varianten via `html.light-mode` bzw. `html:not(.light-mode)`).

## Test plan

- [ ] `php artisan view:clear && php artisan cache:clear` im Haupt-Repo ausführen
- [ ] `/admin/extra-questions` öffnen — neue Page-Title, Stat-Pills, Liste/Empty-State visuell prüfen
- [ ] "Neue Zusatz-Frage" und "Erste Zusatz-Frage anlegen" führen zur Create-Seite
- [ ] Create-Seite: Fragetyp-Wechsel (Zuordnung/Bild benennen/Bild auswählen) lädt jeweils passendes Formular
- [ ] Formulare absenden: alle drei Typen lassen sich anlegen (Validierung + Redirect)
- [ ] Bearbeiten einer bestehenden Frage (jeder Typ) lädt Daten korrekt und speichert
- [ ] Löschen funktioniert (Danger-Zone auf Edit + Row-Icon auf Index)
- [ ] Dark/Light-Mode-Toggle sieht sauber aus
- [ ] Bestehende Tests laufen durch: `php artisan test --filter=ExtraQuestion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)