### PR TITLE
🐛: Zusatz-Fragen Submit & DB-Lernabschnitte

### DIFF
--- a/app/Http/Controllers/Admin/ExtraQuestionController.php
+++ b/app/Http/Controllers/Admin/ExtraQuestionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\ExtraQuestion;
+use App\Models\Question;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
@@ -49,7 +50,9 @@ class ExtraQuestionController extends Controller
             $typ = null;
         }
 
-        return view('admin.extra-questions.create', compact('typ'));
+        $sections = $this->buildLernabschnitte();
+
+        return view('admin.extra-questions.create', compact('typ', 'sections'));
     }
 
     public function store(Request $request)
@@ -85,7 +88,12 @@ class ExtraQuestionController extends Controller
 
         $extra_question->load(['options', 'matchCategories', 'matchItems.correctCategory']);
 
-        return view('admin.extra-questions.edit', ['question' => $extra_question]);
+        $sections = $this->buildLernabschnitte($extra_question->lernabschnitt);
+
+        return view('admin.extra-questions.edit', [
+            'question' => $extra_question,
+            'sections' => $sections,
+        ]);
     }
 
     public function update(Request $request, ExtraQuestion $extra_question)
@@ -160,6 +168,80 @@ class ExtraQuestionController extends Controller
     }
 
     // ----------------- Helpers -----------------
+
+    /**
+     * Offizielle THW-Lernabschnittsnamen (2022).
+     */
+    private const SECTION_NAMES = [
+        1 => 'Das THW im Gefüge des Zivil- und Katastrophenschutzes',
+        2 => 'Arbeitssicherheit und Gesundheitsschutz',
+        3 => 'Arbeiten mit Leinen, Drahtseilen, Ketten, Rund- und Bandschlingen',
+        4 => 'Arbeiten mit Leitern',
+        5 => 'Stromerzeugung und Beleuchtung',
+        6 => 'Metall-, Holz- und Steinbearbeitung',
+        7 => 'Bewegen von Lasten',
+        8 => 'Arbeiten am und auf dem Wasser',
+        9 => 'Einsatzgrundlagen',
+        10 => 'Grundlagen der Rettung und Bergung',
+    ];
+
+    /**
+     * Baut die Lernabschnitt-Auswahl aus der DB:
+     * distinct-Werte aus questions + extra_questions, optional ergänzt um einen
+     * evtl. vorhandenen custom-Wert (z.B. beim Edit).
+     *
+     * @return array<string, string>  value → label
+     */
+    private function buildLernabschnitte(?string $includeValue = null): array
+    {
+        $fromQuestions = Question::query()
+            ->select('lernabschnitt')
+            ->distinct()
+            ->pluck('lernabschnitt');
+
+        $fromExtra = ExtraQuestion::query()
+            ->select('lernabschnitt')
+            ->distinct()
+            ->pluck('lernabschnitt');
+
+        $values = $fromQuestions->merge($fromExtra)
+            ->filter(fn ($v) => $v !== null && $v !== '')
+            ->map(fn ($v) => (string) $v)
+            ->unique()
+            ->values()
+            ->all();
+
+        if ($includeValue !== null && $includeValue !== '' && !in_array($includeValue, $values, true)) {
+            $values[] = $includeValue;
+        }
+
+        usort($values, function ($a, $b) {
+            $aNum = is_numeric($a);
+            $bNum = is_numeric($b);
+            if ($aNum && $bNum) {
+                return (int) $a <=> (int) $b;
+            }
+            if ($aNum !== $bNum) {
+                return $aNum ? -1 : 1;
+            }
+            return strcmp($a, $b);
+        });
+
+        $sections = [];
+        foreach ($values as $val) {
+            $sections[$val] = $this->formatLernabschnittLabel($val);
+        }
+
+        return $sections;
+    }
+
+    private function formatLernabschnittLabel(string $value): string
+    {
+        if (is_numeric($value) && isset(self::SECTION_NAMES[(int) $value])) {
+            return $value . ' – ' . self::SECTION_NAMES[(int) $value];
+        }
+        return $value;
+    }
 
     /**
      * Validiert Request je nach Typ und gibt validierte Daten zurück.

--- a/resources/views/admin/extra-questions/create.blade.php
+++ b/resources/views/admin/extra-questions/create.blade.php
@@ -27,19 +27,6 @@
             'desc'  => 'Textfrage mit 2–6 Bild-Optionen (ein oder mehrere korrekt)',
         ],
     ];
-
-    $sections = [
-        '1'  => '1 – Das THW im Gefüge',
-        '2'  => '2 – Persönliche Ausrüstung',
-        '3'  => '3 – UVV und Rettung',
-        '4'  => '4 – Stromerzeuger & Beleuchtung',
-        '5'  => '5 – Rettungs- und Bergungsarbeiten',
-        '6'  => '6 – Knoten und Stiche',
-        '7'  => '7 – Leitern',
-        '8'  => '8 – Transportieren von Lasten',
-        '9'  => '9 – Einfache Holzverbindungen',
-        '10' => '10 – Erste Hilfe',
-    ];
 @endphp
 
 <div class="dash-container" style="max-width: 52rem;">
@@ -104,13 +91,21 @@
                     <label class="zf-label" for="lernabschnitt">
                         Lernabschnitt <span class="zf-req">*</span>
                     </label>
-                    <select id="lernabschnitt" name="lernabschnitt" class="zf-select" required>
-                        @foreach($sections as $val => $label)
-                            <option value="{{ $val }}" {{ old('lernabschnitt') == $val ? 'selected' : '' }}>
-                                {{ $label }}
-                            </option>
-                        @endforeach
-                    </select>
+                    @if(!empty($sections))
+                        <select id="lernabschnitt" name="lernabschnitt" class="zf-select" required>
+                            @foreach($sections as $val => $label)
+                                <option value="{{ $val }}" {{ old('lernabschnitt') == $val ? 'selected' : '' }}>
+                                    {{ $label }}
+                                </option>
+                            @endforeach
+                        </select>
+                    @else
+                        <input id="lernabschnitt" type="text" name="lernabschnitt"
+                               value="{{ old('lernabschnitt') }}"
+                               class="zf-input" required
+                               placeholder="z.B. 1">
+                        <span class="zf-help">Noch keine Lernabschnitte in der Datenbank – bitte manuell eintragen.</span>
+                    @endif
                     @error('lernabschnitt')<span class="zf-field-error">{{ $message }}</span>@enderror
                 </div>
 
@@ -125,18 +120,25 @@
                 </div>
             </div>
 
-            {{-- Typ-spezifische Partials --}}
-            <div x-show="typ === 'matching'" x-cloak>
-                @include('admin.extra-questions.partials.form-matching', ['question' => null])
-            </div>
+            {{-- Typ-spezifische Partials: x-if statt x-show, damit inaktive `required`-Felder
+                 die Formular-Validierung im Browser nicht blockieren. --}}
+            <template x-if="typ === 'matching'">
+                <div>
+                    @include('admin.extra-questions.partials.form-matching', ['question' => null])
+                </div>
+            </template>
 
-            <div x-show="typ === 'image_name'" x-cloak>
-                @include('admin.extra-questions.partials.form-image-name', ['question' => null])
-            </div>
+            <template x-if="typ === 'image_name'">
+                <div>
+                    @include('admin.extra-questions.partials.form-image-name', ['question' => null])
+                </div>
+            </template>
 
-            <div x-show="typ === 'image_select'" x-cloak>
-                @include('admin.extra-questions.partials.form-image-select', ['question' => null])
-            </div>
+            <template x-if="typ === 'image_select'">
+                <div>
+                    @include('admin.extra-questions.partials.form-image-select', ['question' => null])
+                </div>
+            </template>
 
             <div class="zf-form-actions">
                 <a href="{{ route('admin.extra-questions.index') }}" class="btn-ghost">Abbrechen</a>

--- a/resources/views/admin/extra-questions/edit.blade.php
+++ b/resources/views/admin/extra-questions/edit.blade.php
@@ -53,20 +53,7 @@
         'image_select' => 'bi-grid-3x3-gap-fill',
     ];
 
-    $sections = [
-        '1'  => '1 – Das THW im Gefüge',
-        '2'  => '2 – Persönliche Ausrüstung',
-        '3'  => '3 – UVV und Rettung',
-        '4'  => '4 – Stromerzeuger & Beleuchtung',
-        '5'  => '5 – Rettungs- und Bergungsarbeiten',
-        '6'  => '6 – Knoten und Stiche',
-        '7'  => '7 – Leitern',
-        '8'  => '8 – Transportieren von Lasten',
-        '9'  => '9 – Einfache Holzverbindungen',
-        '10' => '10 – Erste Hilfe',
-    ];
     $currentLern = (string) old('lernabschnitt', $question->lernabschnitt);
-    $hasPredefinedLern = isset($sections[$currentLern]);
 @endphp
 
 <div class="dash-container" style="max-width: 52rem;">
@@ -120,7 +107,7 @@
                 <label class="zf-label" for="lernabschnitt">
                     Lernabschnitt <span class="zf-req">*</span>
                 </label>
-                @if($hasPredefinedLern)
+                @if(!empty($sections))
                     <select id="lernabschnitt" name="lernabschnitt" class="zf-select" required>
                         @foreach($sections as $val => $label)
                             <option value="{{ $val }}" {{ $currentLern === (string) $val ? 'selected' : '' }}>


### PR DESCRIPTION
Lernabschnitte werden nun aus questions + extra_questions geladen statt hardcoded. Submit hängt nicht mehr: inaktive Partials werden per <template x-if> aus dem DOM entfernt, damit versteckte required-Felder die Browser-Validierung nicht blockieren.