### PR TITLE
✨: Bildquelle Pflichtfeld + Vorschau ohne Crop

### DIFF
--- a/app/Http/Controllers/Admin/ExtraQuestionController.php
+++ b/app/Http/Controllers/Admin/ExtraQuestionController.php
@@ -63,8 +63,12 @@ class ExtraQuestionController extends Controller
 
         DB::transaction(function () use ($request, $validated) {
             $imagePath = null;
-            if ($validated['typ'] === ExtraQuestion::TYP_IMAGE_NAME && $request->hasFile('image')) {
-                $imagePath = $request->file('image')->store('extra-questions', 'public');
+            $imageSource = null;
+            if ($validated['typ'] === ExtraQuestion::TYP_IMAGE_NAME) {
+                if ($request->hasFile('image')) {
+                    $imagePath = $request->file('image')->store('extra-questions', 'public');
+                }
+                $imageSource = $validated['image_source'] ?? null;
             }
 
             $question = ExtraQuestion::create([
@@ -72,6 +76,7 @@ class ExtraQuestionController extends Controller
                 'lernabschnitt' => $validated['lernabschnitt'],
                 'frage' => $validated['frage'],
                 'image_path' => $imagePath,
+                'image_source' => $imageSource,
             ]);
 
             $this->persistRelations($question, $request, $validated);
@@ -111,11 +116,14 @@ class ExtraQuestionController extends Controller
             ];
 
             // Frage-Bild (image_name): ggf. ersetzen
-            if ($extra_question->typ === ExtraQuestion::TYP_IMAGE_NAME && $request->hasFile('image')) {
-                if ($extra_question->image_path) {
-                    Storage::disk('public')->delete($extra_question->image_path);
+            if ($extra_question->typ === ExtraQuestion::TYP_IMAGE_NAME) {
+                if ($request->hasFile('image')) {
+                    if ($extra_question->image_path) {
+                        Storage::disk('public')->delete($extra_question->image_path);
+                    }
+                    $updateData['image_path'] = $request->file('image')->store('extra-questions', 'public');
                 }
-                $updateData['image_path'] = $request->file('image')->store('extra-questions', 'public');
+                $updateData['image_source'] = $validated['image_source'] ?? null;
             }
 
             $extra_question->update($updateData);
@@ -261,6 +269,7 @@ class ExtraQuestionController extends Controller
             $imageRule = $existing ? 'nullable' : 'required';
             $rules = array_merge($rules, [
                 'image' => $imageRule . '|image|mimes:jpeg,png,jpg,webp|max:5120',
+                'image_source' => 'required|string|max:255',
                 'options' => 'required|array|min:2|max:6',
                 'options.*.text' => 'required|string',
                 'options.*.is_correct' => 'required|boolean',
@@ -271,6 +280,7 @@ class ExtraQuestionController extends Controller
             $rules = array_merge($rules, [
                 'options' => 'required|array|min:2|max:6',
                 'options.*.image' => 'required|image|mimes:jpeg,png,jpg,webp|max:5120',
+                'options.*.image_source' => 'required|string|max:255',
                 'options.*.is_correct' => 'required|boolean',
             ]);
         } elseif ($typ === ExtraQuestion::TYP_MATCHING) {
@@ -354,6 +364,7 @@ class ExtraQuestionController extends Controller
                 }
                 $question->options()->create([
                     'image_path' => $optImagePath,
+                    'image_source' => $optData['image_source'] ?? null,
                     'is_correct' => (bool) $optData['is_correct'],
                     'sort_order' => $i,
                 ]);

--- a/app/Models/ExtraQuestion.php
+++ b/app/Models/ExtraQuestion.php
@@ -14,6 +14,7 @@ class ExtraQuestion extends Model
         'lernabschnitt',
         'frage',
         'image_path',
+        'image_source',
     ];
 
     protected $casts = [

--- a/app/Models/ExtraQuestionOption.php
+++ b/app/Models/ExtraQuestionOption.php
@@ -10,6 +10,7 @@ class ExtraQuestionOption extends Model
         'extra_question_id',
         'text',
         'image_path',
+        'image_source',
         'is_correct',
         'sort_order',
     ];

--- a/database/migrations/2026_04_20_100001_add_image_source_to_extra_questions_and_options.php
+++ b/database/migrations/2026_04_20_100001_add_image_source_to_extra_questions_and_options.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('extra_questions', function (Blueprint $table) {
+            $table->string('image_source')->nullable()->after('image_path');
+        });
+
+        Schema::table('extra_question_options', function (Blueprint $table) {
+            $table->string('image_source')->nullable()->after('image_path');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('extra_questions', function (Blueprint $table) {
+            $table->dropColumn('image_source');
+        });
+
+        Schema::table('extra_question_options', function (Blueprint $table) {
+            $table->dropColumn('image_source');
+        });
+    }
+};

--- a/resources/views/admin/extra-questions/partials/form-image-name.blade.php
+++ b/resources/views/admin/extra-questions/partials/form-image-name.blade.php
@@ -63,6 +63,17 @@
     </template>
 
     @error('image')<span class="zf-field-error">{{ $message }}</span>@enderror
+
+    <div class="zf-field" style="margin-top: 0.75rem;">
+        <label class="zf-label" for="image_source">
+            Bildquelle <span class="zf-req">*</span>
+        </label>
+        <input id="image_source" type="text" name="image_source" class="zf-input"
+               value="{{ old('image_source', $question->image_source ?? '') }}"
+               placeholder="z.B. THW / Fotograf / CC-BY 4.0" required>
+        <span class="zf-help">Urheber oder Quelle des Bildes – wird unter der Frage angezeigt.</span>
+        @error('image_source')<span class="zf-field-error">{{ $message }}</span>@enderror
+    </div>
 </div>
 
 {{-- Text-Optionen --}}

--- a/resources/views/admin/extra-questions/partials/form-image-select.blade.php
+++ b/resources/views/admin/extra-questions/partials/form-image-select.blade.php
@@ -6,12 +6,14 @@
         foreach (old('options') as $o) {
             $initialOptions[] = [
                 'is_correct' => !empty($o['is_correct']),
+                'image_source' => $o['image_source'] ?? '',
             ];
         }
     } elseif (isset($question) && $question && $question->options->count()) {
         foreach ($question->options as $opt) {
             $initialOptions[] = [
                 'is_correct' => (bool) $opt->is_correct,
+                'image_source' => (string) ($opt->image_source ?? ''),
             ];
             $existingImageUrls[] = $opt->image_path
                 ? \Illuminate\Support\Facades\Storage::url($opt->image_path)
@@ -19,8 +21,8 @@
         }
     } else {
         $initialOptions = [
-            ['is_correct' => false],
-            ['is_correct' => false],
+            ['is_correct' => false, 'image_source' => ''],
+            ['is_correct' => false, 'image_source' => ''],
         ];
     }
 
@@ -36,7 +38,7 @@
         this.previews[i] = f ? URL.createObjectURL(f) : null;
     },
     addOption() {
-        if (this.options.length < 6) this.options.push({ is_correct: false });
+        if (this.options.length < 6) this.options.push({ is_correct: false, image_source: '' });
     },
     removeOption(i) {
         if (this.options.length > 2) {
@@ -112,6 +114,13 @@
                         </div>
                         <div class="zf-upload__sub">JPG, PNG oder WebP · max. 5 MB</div>
                     </label>
+                    <input type="text"
+                           class="zf-input"
+                           :name="`options[${i}][image_source]`"
+                           x-model="opt.image_source"
+                           placeholder="Bildquelle (z.B. THW / Fotograf)"
+                           required
+                           style="margin-top: 0.5rem;">
                 </div>
             </div>
         </template>

--- a/resources/views/practice/partials/question-image-name.blade.php
+++ b/resources/views/practice/partials/question-image-name.blade.php
@@ -58,6 +58,18 @@
     .iname-options .answer-opt { /* nutzt bestehendes answer-opt */
         align-items: center;
     }
+
+    .img-source {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        margin-top: -0.25rem;
+    }
+    .img-source strong {
+        color: var(--text-muted);
+        font-weight: 600;
+        margin-right: 0.25rem;
+    }
 </style>
 
 <div class="iname-wrap">
@@ -78,6 +90,10 @@
     </div>
 
     <p class="question-text">{{ $question->frage }}</p>
+
+    @if(!empty($question->image_source))
+        <p class="img-source"><strong>Bildquelle:</strong> {{ $question->image_source }}</p>
+    @endif
 
     {{-- Bild --}}
     <div class="iname-frame">

--- a/resources/views/practice/partials/question-image-select.blade.php
+++ b/resources/views/practice/partials/question-image-select.blade.php
@@ -9,6 +9,12 @@
         $raw = is_string($userAnswer) ? explode(',', $userAnswer) : (array) $userAnswer;
         $userAnswerIds = collect($raw)->map(fn($v) => (int) $v)->filter();
     }
+    $imageSources = $options
+        ->pluck('image_source')
+        ->filter(fn($v) => !empty($v))
+        ->map(fn($v) => trim($v))
+        ->unique()
+        ->values();
 @endphp
 
 <style>
@@ -25,7 +31,9 @@
 
     .isel-card {
         position: relative;
-        display: block;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         border-radius: 0.875rem;
         overflow: hidden;
         cursor: pointer;
@@ -34,6 +42,7 @@
         transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
         aspect-ratio: 4 / 3;
         min-height: 44px;
+        padding: 0.35rem;
     }
     html.light-mode .isel-card {
         background: #f8fafc;
@@ -51,9 +60,11 @@
     }
 
     .isel-card img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
+        max-width: 100%;
+        max-height: 100%;
+        width: auto;
+        height: auto;
+        object-fit: contain;
         display: block;
     }
 
@@ -137,6 +148,18 @@
         width: 0; height: 0;
         pointer-events: none;
     }
+
+    .img-source {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+        margin-top: -0.25rem;
+    }
+    .img-source strong {
+        color: var(--text-muted);
+        font-weight: 600;
+        margin-right: 0.25rem;
+    }
 </style>
 
 <div class="isel-wrap">
@@ -157,6 +180,10 @@
     </div>
 
     <p class="question-text">{{ $question->frage }}</p>
+
+    @if($imageSources->isNotEmpty())
+        <p class="img-source"><strong>Bildquelle:</strong> {{ $imageSources->join(', ') }}</p>
+    @endif
 
     {{-- Ergebnis-Banner --}}
     @if(isset($isCorrect))


### PR DESCRIPTION
- image-select Kacheln zeigen Bilder nun vollständig (contain statt cover).
- Neue Spalte image_source auf extra_questions und extra_question_options.
- Admin-Formulare verlangen Bildquelle pro Bild (image_name + image_select).
- Practice blendet unter der Frage "Bildquelle: X" ein; bei mehreren verschiedenen Quellen komma-getrennt.