### PR TITLE
feat: add views to see and manage ausbildungsfortschritt per member

### DIFF
--- a/app/Http/Controllers/OrtsverbandController.php
+++ b/app/Http/Controllers/OrtsverbandController.php
@@ -4,8 +4,12 @@ namespace App\Http\Controllers;
 
 use App\Models\Ortsverband;
 use App\Models\User;
+use App\Models\UserTrainingProgress;
+use App\Services\TrainingProgressService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 class OrtsverbandController extends Controller
 {
@@ -198,6 +202,136 @@ class OrtsverbandController extends Controller
         $ausbilderProgress = $allMemberProgress->filter(fn($m) => $m['role'] === 'ausbildungsbeauftragter');
         
         return view('ortsverband.members', compact('ortsverband', 'memberProgress', 'ausbilderProgress'));
+    }
+
+    /**
+     * Zeigt die Prüfling-Verwalten-Seite mit Ausbildungsfortschritt
+     */
+    public function manageMember(Ortsverband $ortsverband, User $user)
+    {
+        $this->authorizeManageMember($ortsverband, $user);
+
+        $service = new TrainingProgressService();
+
+        $totalQuestions = \App\Models\Question::count();
+        $masteredCount = \App\Models\UserQuestionProgress::where('user_id', $user->id)
+            ->where('consecutive_correct', '>=', \App\Models\UserQuestionProgress::MASTERY_THRESHOLD)
+            ->count();
+
+        $answeredTotal = \App\Models\QuestionStatistic::where('user_id', $user->id)->count();
+        $answeredCorrect = \App\Models\QuestionStatistic::where('user_id', $user->id)->where('is_correct', true)->count();
+        $accuracyPercent = $answeredTotal > 0 ? (int) round(($answeredCorrect / $answeredTotal) * 100) : 0;
+
+        $examsTotal = \App\Models\ExamStatistic::where('user_id', $user->id)->count();
+        $examsPassed = \App\Models\ExamStatistic::where('user_id', $user->id)->where('is_passed', true)->count();
+        $lastExam = \App\Models\ExamStatistic::where('user_id', $user->id)->latest()->first();
+
+        $examStreak = 0;
+        foreach (\App\Models\ExamStatistic::where('user_id', $user->id)->orderBy('created_at', 'desc')->get() as $exam) {
+            if ($exam->is_passed) {
+                $examStreak++;
+            } else {
+                break;
+            }
+        }
+
+        $stats = [
+            'total_questions' => $totalQuestions,
+            'mastered_count' => $masteredCount,
+            'mastered_percent' => $totalQuestions > 0 ? (int) round(($masteredCount / $totalQuestions) * 100) : 0,
+            'answered_total' => $answeredTotal,
+            'answered_correct' => $answeredCorrect,
+            'accuracy_percent' => $accuracyPercent,
+            'exams_total' => $examsTotal,
+            'exams_passed' => $examsPassed,
+            'exam_streak' => $examStreak,
+            'last_exam' => $lastExam,
+        ];
+
+        return view('ortsverband.members.manage', [
+            'ortsverband' => $ortsverband,
+            'member' => $user,
+            'stats' => $stats,
+            'trainingOverview' => $service->overview($user),
+            'trainingLernabschnitte' => TrainingProgressService::LERNABSCHNITTE,
+            'trainingZusatzausbildungen' => TrainingProgressService::ZUSATZAUSBILDUNGEN,
+        ]);
+    }
+
+    /**
+     * Toggle eines einzelnen Ausbildungsfortschritt-Eintrags für ein Mitglied
+     */
+    public function toggleMemberTrainingItem(Request $request, Ortsverband $ortsverband, User $user): JsonResponse
+    {
+        $this->authorizeManageMember($ortsverband, $user);
+
+        $data = $request->validate([
+            'item_key' => ['required', 'string', Rule::in(TrainingProgressService::validItemKeys())],
+            'completed' => ['required', 'boolean'],
+        ]);
+
+        if ($data['completed']) {
+            UserTrainingProgress::firstOrCreate(
+                ['user_id' => $user->id, 'item_key' => $data['item_key']],
+                ['completed_at' => now()],
+            );
+        } else {
+            UserTrainingProgress::where('user_id', $user->id)
+                ->where('item_key', $data['item_key'])
+                ->delete();
+        }
+
+        return response()->json([
+            'success' => true,
+            'overview' => (new TrainingProgressService())->overview($user),
+        ]);
+    }
+
+    /**
+     * Toggle eines ganzen Lernabschnitts für ein Mitglied
+     */
+    public function toggleMemberTrainingSection(Request $request, Ortsverband $ortsverband, User $user): JsonResponse
+    {
+        $this->authorizeManageMember($ortsverband, $user);
+
+        $data = $request->validate([
+            'section_key' => ['required', 'string', Rule::in(TrainingProgressService::validSectionKeys())],
+            'completed' => ['required', 'boolean'],
+        ]);
+
+        $itemKeys = TrainingProgressService::itemKeysForSection($data['section_key']);
+
+        if ($data['completed']) {
+            $now = now();
+            $rows = array_map(fn ($key) => [
+                'user_id' => $user->id,
+                'item_key' => $key,
+                'completed_at' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ], $itemKeys);
+            UserTrainingProgress::upsert($rows, ['user_id', 'item_key'], ['completed_at', 'updated_at']);
+        } else {
+            UserTrainingProgress::where('user_id', $user->id)
+                ->whereIn('item_key', $itemKeys)
+                ->delete();
+        }
+
+        return response()->json([
+            'success' => true,
+            'overview' => (new TrainingProgressService())->overview($user),
+        ]);
+    }
+
+    private function authorizeManageMember(Ortsverband $ortsverband, User $user): void
+    {
+        if (!$ortsverband->isAusbildungsbeauftragter(Auth::user())) {
+            abort(403, 'Keine Berechtigung.');
+        }
+
+        if (!$ortsverband->isMember($user)) {
+            abort(404, 'Mitglied nicht in diesem Ortsverband.');
+        }
     }
 
     /**

--- a/app/Models/Ortsverband.php
+++ b/app/Models/Ortsverband.php
@@ -95,18 +95,19 @@ class Ortsverband extends Model
     public function getMemberProgress()
     {
         $totalQuestions = \App\Models\Question::count();
-        
-        return $this->members->map(function($member) use ($totalQuestions) {
+        $trainingService = new \App\Services\TrainingProgressService();
+
+        return $this->members->map(function($member) use ($totalQuestions, $trainingService) {
             // Theorie-Fortschritt
             $solvedQuestions = \App\Models\UserQuestionProgress::where('user_id', $member->id)
                               ->where('consecutive_correct', '>=', \App\Models\UserQuestionProgress::MASTERY_THRESHOLD)
                               ->count();
-            
+
             // Prüfungs-Streak
             $allExams = \App\Models\ExamStatistic::where('user_id', $member->id)
                 ->orderBy('created_at', 'desc')
                 ->get();
-            
+
             $examStreak = 0;
             foreach ($allExams as $exam) {
                 if ($exam->is_passed) {
@@ -115,11 +116,17 @@ class Ortsverband extends Model
                     break;
                 }
             }
-            
+
+            $trainingOverview = $trainingService->overview($member);
+
             return [
                 'user' => $member,
                 'theory_progress_percent' => $totalQuestions > 0 ? round(($solvedQuestions / $totalQuestions) * 100) : 0,
                 'theory_progress_count' => $solvedQuestions,
+                'theory_progress_total' => $totalQuestions,
+                'training_progress_percent' => $trainingOverview['percent'],
+                'training_progress_done' => $trainingOverview['done'],
+                'training_progress_total' => $trainingOverview['total'],
                 'exams_passed' => $examStreak,
                 'streak' => $member->streak_days ?? 0,
                 'level' => $member->level ?? 1,

--- a/database/seeders/AusbildungsfortschrittDemoSeeder.php
+++ b/database/seeders/AusbildungsfortschrittDemoSeeder.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\ExamStatistic;
+use App\Models\Ortsverband;
+use App\Models\Question;
+use App\Models\QuestionStatistic;
+use App\Models\User;
+use App\Models\UserQuestionProgress;
+use App\Models\UserTrainingProgress;
+use App\Services\TrainingProgressService;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+class AusbildungsfortschrittDemoSeeder extends Seeder
+{
+    private const EXAM_SIZE = 40;
+    private const EXAM_PASS_THRESHOLD = 32;
+
+    public function run(): void
+    {
+        $ausbilder = User::updateOrCreate(
+            ['email' => 'ausbilder@example.com'],
+            [
+                'name' => 'Anja Ausbilder',
+                'password' => Hash::make('password'),
+                'email_verified_at' => now(),
+                'useroll' => 'user',
+            ],
+        );
+
+        $ortsverband = Ortsverband::firstOrCreate(
+            ['created_by' => $ausbilder->id],
+            [
+                'name' => 'OV Demo-Stadt',
+                'description' => 'Demo-Ortsverband für Ausbildungsfortschritt',
+            ],
+        );
+
+        DB::table('ortsverband_members')->updateOrInsert(
+            ['ortsverband_id' => $ortsverband->id, 'user_id' => $ausbilder->id],
+            ['role' => 'ausbildungsbeauftragter', 'joined_at' => now(), 'updated_at' => now(), 'created_at' => now()],
+        );
+
+        $allItemKeys = TrainingProgressService::validItemKeys();
+        $questionIds = Question::orderBy('id')->pluck('id')->all();
+        $totalQuestions = count($questionIds);
+
+        $members = [
+            [
+                'email' => 'vollstaendig@example.com',
+                'name' => 'Max Vollständig',
+                'training_keys' => $allItemKeys,
+                'mastered_ratio' => 1.0,
+                'partial_ratio' => 0.0,
+                'passed_exams' => 10,
+                'failed_exams' => 0,
+            ],
+            [
+                'email' => 'neuling@example.com',
+                'name' => 'Lukas Neuling',
+                'training_keys' => [],
+                'mastered_ratio' => 0.0,
+                'partial_ratio' => 0.0,
+                'passed_exams' => 0,
+                'failed_exams' => 0,
+            ],
+            [
+                'email' => 'fortgeschritten@example.com',
+                'name' => 'Anna Fortgeschritten',
+                'training_keys' => array_slice($allItemKeys, 0, (int) round(count($allItemKeys) * 0.7)),
+                'mastered_ratio' => 0.7,
+                'partial_ratio' => 0.15,
+                'passed_exams' => 5,
+                'failed_exams' => 1,
+            ],
+            [
+                'email' => 'anfaenger@example.com',
+                'name' => 'Ben Anfänger',
+                'training_keys' => array_slice($allItemKeys, 0, (int) round(count($allItemKeys) * 0.3)),
+                'mastered_ratio' => 0.3,
+                'partial_ratio' => 0.2,
+                'passed_exams' => 1,
+                'failed_exams' => 2,
+            ],
+        ];
+
+        foreach ($members as $data) {
+            $user = User::updateOrCreate(
+                ['email' => $data['email']],
+                [
+                    'name' => $data['name'],
+                    'password' => Hash::make('password'),
+                    'email_verified_at' => now(),
+                    'useroll' => 'user',
+                ],
+            );
+
+            DB::table('ortsverband_members')->updateOrInsert(
+                ['ortsverband_id' => $ortsverband->id, 'user_id' => $user->id],
+                ['role' => 'member', 'joined_at' => now(), 'updated_at' => now(), 'created_at' => now()],
+            );
+
+            $this->seedTrainingProgress($user, $data['training_keys']);
+            $this->seedQuestionAndExamProgress($user, $questionIds, $totalQuestions, $data);
+        }
+    }
+
+    private function seedTrainingProgress(User $user, array $keys): void
+    {
+        UserTrainingProgress::where('user_id', $user->id)->delete();
+
+        if (empty($keys)) {
+            return;
+        }
+
+        $now = now();
+        $rows = array_map(fn ($key) => [
+            'user_id' => $user->id,
+            'item_key' => $key,
+            'completed_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ], $keys);
+
+        UserTrainingProgress::insert($rows);
+    }
+
+    private function seedQuestionAndExamProgress(User $user, array $questionIds, int $totalQuestions, array $data): void
+    {
+        UserQuestionProgress::where('user_id', $user->id)->delete();
+        QuestionStatistic::where('user_id', $user->id)->delete();
+        ExamStatistic::where('user_id', $user->id)->delete();
+
+        $user->exam_passed_count = 0;
+        $user->solved_questions = [];
+        $user->exam_failed_questions = [];
+        $user->save();
+
+        if ($totalQuestions === 0) {
+            return;
+        }
+
+        $masteredCount = (int) round($totalQuestions * $data['mastered_ratio']);
+        $partialCount = (int) round($totalQuestions * $data['partial_ratio']);
+        $partialCount = min($partialCount, $totalQuestions - $masteredCount);
+
+        $masteredIds = array_slice($questionIds, 0, $masteredCount);
+        $partialIds = array_slice($questionIds, $masteredCount, $partialCount);
+
+        $now = now();
+        $progressRows = [];
+
+        foreach ($masteredIds as $qid) {
+            $progressRows[] = [
+                'user_id' => $user->id,
+                'question_id' => $qid,
+                'consecutive_correct' => UserQuestionProgress::MASTERY_THRESHOLD,
+                'last_answered_at' => $now,
+                'next_review_at' => $now->copy()->addDays(7),
+                'review_interval' => 7,
+                'easiness_factor' => 2.5,
+                'repetition_count' => 3,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+
+        foreach ($partialIds as $i => $qid) {
+            $level = ($i % 2) + 1;
+            $progressRows[] = [
+                'user_id' => $user->id,
+                'question_id' => $qid,
+                'consecutive_correct' => $level,
+                'last_answered_at' => $now,
+                'next_review_at' => $now->copy()->addDays($level),
+                'review_interval' => $level,
+                'easiness_factor' => 2.5,
+                'repetition_count' => $level,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+
+        if (!empty($progressRows)) {
+            foreach (array_chunk($progressRows, 200) as $chunk) {
+                UserQuestionProgress::insert($chunk);
+            }
+        }
+
+        $user->solved_questions = $masteredIds;
+        $user->save();
+
+        $this->seedExams($user, $questionIds, $data['passed_exams'], $data['failed_exams']);
+
+        $practicePool = array_merge($masteredIds, $partialIds);
+        if (!empty($practicePool)) {
+            $this->seedPracticeStatistics($user, $practicePool, $data['mastered_ratio']);
+        }
+    }
+
+    private function seedExams(User $user, array $questionIds, int $passedCount, int $failedCount): void
+    {
+        $totalExams = $passedCount + $failedCount;
+        if ($totalExams === 0) {
+            return;
+        }
+
+        $baseTime = Carbon::now()->subDays($totalExams);
+        $sequence = array_merge(
+            array_fill(0, $failedCount, false),
+            array_fill(0, $passedCount, true),
+        );
+
+        $lastFailedIds = [];
+
+        foreach ($sequence as $i => $isPassed) {
+            $examTime = $baseTime->copy()->addDays($i)->addHours(18);
+
+            $ids = $questionIds;
+            shuffle($ids);
+            $examIds = array_slice($ids, 0, min(self::EXAM_SIZE, count($ids)));
+
+            if ($isPassed) {
+                $correctCount = rand(self::EXAM_PASS_THRESHOLD, count($examIds));
+            } else {
+                $correctCount = rand(15, self::EXAM_PASS_THRESHOLD - 1);
+            }
+
+            $exam = ExamStatistic::create([
+                'user_id' => $user->id,
+                'is_passed' => $isPassed,
+                'correct_answers' => $correctCount,
+            ]);
+            $exam->created_at = $examTime;
+            $exam->updated_at = $examTime;
+            $exam->save();
+
+            $correctSet = array_flip(array_slice($examIds, 0, $correctCount));
+            $failedInExam = [];
+            $statRows = [];
+            foreach ($examIds as $qid) {
+                $correct = isset($correctSet[$qid]);
+                if (!$correct) {
+                    $failedInExam[] = $qid;
+                }
+                $statRows[] = [
+                    'question_id' => $qid,
+                    'user_id' => $user->id,
+                    'is_correct' => $correct,
+                    'source' => 'exam',
+                    'exam_statistic_id' => $exam->id,
+                    'created_at' => $examTime,
+                    'updated_at' => $examTime,
+                ];
+            }
+            QuestionStatistic::insert($statRows);
+
+            if (!$isPassed) {
+                $lastFailedIds = $failedInExam;
+            }
+        }
+
+        $trailingPassedStreak = 0;
+        foreach (array_reverse($sequence) as $isPassed) {
+            if ($isPassed) {
+                $trailingPassedStreak++;
+            } else {
+                break;
+            }
+        }
+
+        $user->exam_passed_count = $trailingPassedStreak;
+        $user->exam_failed_questions = $trailingPassedStreak === count($sequence) ? [] : $lastFailedIds;
+        $user->save();
+    }
+
+    private function seedPracticeStatistics(User $user, array $questionIds, float $masteredRatio): void
+    {
+        $sampleSize = min(count($questionIds), 50);
+        $sample = array_slice($questionIds, 0, $sampleSize);
+
+        $correctProbability = max(0.5, min(0.95, 0.5 + $masteredRatio * 0.45));
+        $rows = [];
+        $start = Carbon::now()->subDays(30);
+
+        foreach ($sample as $i => $qid) {
+            $isCorrect = (mt_rand(1, 100) / 100) <= $correctProbability;
+            $ts = $start->copy()->addHours($i * 4);
+            $rows[] = [
+                'question_id' => $qid,
+                'user_id' => $user->id,
+                'is_correct' => $isCorrect,
+                'source' => 'practice',
+                'exam_statistic_id' => null,
+                'created_at' => $ts,
+                'updated_at' => $ts,
+            ];
+        }
+
+        if (!empty($rows)) {
+            foreach (array_chunk($rows, 200) as $chunk) {
+                QuestionStatistic::insert($chunk);
+            }
+        }
+    }
+}

--- a/resources/views/ortsverband/dashboard.blade.php
+++ b/resources/views/ortsverband/dashboard.blade.php
@@ -202,9 +202,15 @@
                     <img src="{{ $mUser->avatar_url }}" alt="" style="width:36px;height:36px;border-radius:50%;object-fit:cover;flex-shrink:0;">
                     <div style="flex:1;min-width:0;">
                         <div style="display:flex;align-items:center;gap:0.375rem;margin-bottom:0.15rem;">
-                            <span class="{{ trim($mNameClasses) }}" style="font-weight:700;font-size:0.8125rem;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
-                                {{ $mUser->name }}
-                            </span>
+                            @if($mUser->id !== auth()->id())
+                                <a href="{{ route('ortsverband.members.manage', [$ortsverband, $mUser]) }}" class="{{ trim($mNameClasses) }}" style="font-weight:700;font-size:0.8125rem;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;text-decoration:none;">
+                                    {{ $mUser->name }}
+                                </a>
+                            @else
+                                <span class="{{ trim($mNameClasses) }}" style="font-weight:700;font-size:0.8125rem;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+                                    {{ $mUser->name }}
+                                </span>
+                            @endif
                             @if($member['role'] === 'ausbildungsbeauftragter')
                                 <span style="font-size:0.5rem;padding:0.1rem 0.35rem;border-radius:2rem;background:rgba(91,154,255,0.12);color:#5b9aff;font-weight:700;font-family:'IBM Plex Mono',monospace;white-space:nowrap;">Ausbilder</span>
                             @endif
@@ -212,14 +218,20 @@
                         @if($mHasTitle)
                             <div class="user-title" style="font-size:0.625rem;margin-bottom:0.15rem;">{{ $mUser->active_title }}</div>
                         @endif
-                        <div style="display:flex;gap:0.75rem;font-size:0.6875rem;color:var(--text-muted);">
+                        <div style="display:flex;gap:0.75rem;font-size:0.6875rem;color:var(--text-muted);flex-wrap:wrap;">
                             <span>Theorie {{ $member['theory_progress_percent'] }}%</span>
+                            <span>Ausbildung {{ $member['training_progress_percent'] }}%</span>
                             <span>{{ $member['exams_passed'] }}/5 Prüf.</span>
                             <span>{{ $member['streak'] }}d Streak</span>
                             <span>Lvl {{ $member['level'] }}</span>
                         </div>
-                        <div class="ov-progress-track" style="margin-top:0.375rem;">
-                            <div style="height:100%;border-radius:2px;background:linear-gradient(90deg,#0055cc,#5b9aff);width:{{ $member['theory_progress_percent'] }}%;transition:width 0.6s ease-out;"></div>
+                        <div style="display:flex;gap:0.5rem;margin-top:0.375rem;">
+                            <div class="ov-progress-track" style="flex:1;" title="Theorie-Fortschritt">
+                                <div style="height:100%;border-radius:2px;background:linear-gradient(90deg,#0055cc,#5b9aff);width:{{ $member['theory_progress_percent'] }}%;transition:width 0.6s ease-out;"></div>
+                            </div>
+                            <div class="ov-progress-track" style="flex:1;" title="Ausbildungsfortschritt">
+                                <div style="height:100%;border-radius:2px;background:linear-gradient(90deg,#8a6d10,#d4a017);width:{{ $member['training_progress_percent'] }}%;transition:width 0.6s ease-out;"></div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/resources/views/ortsverband/members.blade.php
+++ b/resources/views/ortsverband/members.blade.php
@@ -88,10 +88,15 @@ html.light-mode .ov-progress-track-lg {
 @section('content')
 <div class="dash-container">
 
-    <div class="mb-6">
-        <p style="font-size:0.75rem;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-muted);font-weight:600;margin-bottom:0.25rem;">Verwaltung</p>
-        <h1 style="font-size:1.5rem;font-weight:800;line-height:1.2;font-family:'Barlow Condensed',sans-serif;background:linear-gradient(135deg,#5b9aff,#0055cc);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;">Mitglieder verwalten</h1>
-        <p class="text-sm" style="color: var(--text-muted);">{{ $ortsverband->name }}</p>
+    <div class="mb-6" style="display:flex;align-items:center;gap:1rem;flex-wrap:wrap;">
+        <div style="flex:1;min-width:0;">
+            <p style="font-size:0.75rem;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-muted);font-weight:600;margin-bottom:0.25rem;">Verwaltung</p>
+            <h1 style="font-size:1.5rem;font-weight:800;line-height:1.2;font-family:'Barlow Condensed',sans-serif;background:linear-gradient(135deg,#5b9aff,#0055cc);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;">Mitglieder verwalten</h1>
+            <p class="text-sm" style="color: var(--text-muted);">{{ $ortsverband->name }}</p>
+        </div>
+        <a href="{{ route('ortsverband.invitations.index', $ortsverband) }}" class="btn-primary btn-sm" style="text-decoration:none;flex-shrink:0;">
+            Einladen
+        </a>
     </div>
 
     @if(session('success'))
@@ -119,9 +124,6 @@ html.light-mode .ov-progress-track-lg {
             <div class="gami-pill__value" style="color:#5b9aff;-webkit-text-fill-color:#5b9aff;">{{ $ausbilderProgress->count() }}</div>
             <div class="gami-pill__label">Ausbilder</div>
         </div>
-        <a href="{{ route('ortsverband.invitations.index', $ortsverband) }}" class="btn-primary btn-sm" style="margin-left: auto;">
-            Einladen
-        </a>
     </div>
 
     <div class="space-y-4">
@@ -184,6 +186,9 @@ html.light-mode .ov-progress-track-lg {
                             </div>
                         </div>
                         <div style="display: flex; gap: 0.5rem; flex-shrink: 0;">
+                            <a href="{{ route('ortsverband.members.manage', [$ortsverband, $member['user']]) }}" class="btn-primary btn-sm" style="text-decoration:none;">
+                                Verwalten
+                            </a>
                             <form action="{{ route('ortsverband.members.role', [$ortsverband, $member['user']]) }}" method="POST" style="display: inline;">
                                 @csrf
                                 @method('PUT')
@@ -201,13 +206,24 @@ html.light-mode .ov-progress-track-lg {
                     </div>
 
                     {{-- Progress --}}
-                    <div style="margin-bottom: 0.75rem;">
-                        <div style="display: flex; justify-content: space-between; font-size: 0.75rem; color: var(--text-secondary); margin-bottom: 0.25rem;">
-                            <span>Theorie-Fortschritt</span>
-                            <span>{{ $member['theory_progress_count'] }}/268 ({{ $member['theory_progress_percent'] }}%)</span>
+                    <div style="display: flex; gap: 0.75rem; margin-bottom: 0.75rem;">
+                        <div style="flex: 1; min-width: 0;">
+                            <div style="display: flex; justify-content: space-between; font-size: 0.75rem; color: var(--text-secondary); margin-bottom: 0.25rem;">
+                                <span>Theorie</span>
+                                <span>{{ $member['theory_progress_count'] }}/{{ $member['theory_progress_total'] }} ({{ $member['theory_progress_percent'] }}%)</span>
+                            </div>
+                            <div class="ov-progress-track-lg">
+                                <div style="height: 100%; background: linear-gradient(135deg,#5b9aff,#0055cc); width: {{ $member['theory_progress_percent'] }}%; border-radius: 2px;"></div>
+                            </div>
                         </div>
-                        <div class="ov-progress-track-lg">
-                            <div style="height: 100%; background: linear-gradient(135deg,#5b9aff,#0055cc); width: {{ $member['theory_progress_percent'] }}%; border-radius: 2px;"></div>
+                        <div style="flex: 1; min-width: 0;">
+                            <div style="display: flex; justify-content: space-between; font-size: 0.75rem; color: var(--text-secondary); margin-bottom: 0.25rem;">
+                                <span>Ausbildung</span>
+                                <span>{{ $member['training_progress_done'] }}/{{ $member['training_progress_total'] }} ({{ $member['training_progress_percent'] }}%)</span>
+                            </div>
+                            <div class="ov-progress-track-lg">
+                                <div style="height: 100%; background: linear-gradient(135deg,#d4a017,#8a6d10); width: {{ $member['training_progress_percent'] }}%; border-radius: 2px;"></div>
+                            </div>
                         </div>
                     </div>
 

--- a/resources/views/ortsverband/members/manage.blade.php
+++ b/resources/views/ortsverband/members/manage.blade.php
@@ -1,0 +1,519 @@
+@extends('layouts.app')
+
+@section('title', $member->name . ' verwalten - ' . $ortsverband->name)
+
+@push('styles')
+<link rel="preconnect" href="https://fonts.bunny.net">
+<link href="https://fonts.bunny.net/css2?family=Barlow+Condensed:wght@600;700;800&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+    .dash-container { max-width: 1180px; padding: 0 1rem; }
+
+    .mm-head {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin: 1rem 0 1.25rem;
+        flex-wrap: wrap;
+    }
+    .mm-head__avatar {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        object-fit: cover;
+        flex-shrink: 0;
+    }
+    .mm-head__text { flex: 1; min-width: 0; }
+    .mm-head__eyebrow {
+        font-size: 0.6875rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-muted);
+        font-family: 'IBM Plex Mono', monospace;
+    }
+    .mm-head__name {
+        font-size: 1.5rem;
+        font-weight: 800;
+        line-height: 1.2;
+        font-family: 'Barlow Condensed', sans-serif;
+        background: linear-gradient(135deg,#5b9aff,#0055cc);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+        margin: 0.1rem 0 0.2rem;
+    }
+    .mm-head__email { font-size: 0.875rem; color: var(--text-muted); }
+
+    .mm-stats {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 0.75rem;
+    }
+    @media (max-width: 860px) { .mm-stats { grid-template-columns: repeat(2, 1fr); } }
+    @media (max-width: 480px) { .mm-stats { grid-template-columns: 1fr; } }
+    .mm-stat {
+        padding: 0.875rem 1rem;
+        border-radius: 0.625rem;
+        background: rgba(0, 51, 127, 0.04);
+        border: 1px solid rgba(0, 51, 127, 0.1);
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+    }
+    html:not(.light-mode) .mm-stat {
+        background: rgba(91, 154, 255, 0.04);
+        border-color: rgba(91, 154, 255, 0.12);
+    }
+    .mm-stat__label {
+        font-size: 0.6875rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--text-muted);
+        font-family: 'IBM Plex Mono', monospace;
+    }
+    .mm-stat__value {
+        font-size: 1.375rem;
+        font-weight: 700;
+        color: var(--text-primary);
+        line-height: 1.1;
+    }
+    .mm-stat__meta {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+    }
+
+    .tp-card { padding: 1.5rem; border-radius: 0.75rem; }
+
+    .tp-summary {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.75rem;
+        margin-bottom: 1.5rem;
+    }
+    @media (max-width: 640px) { .tp-summary { grid-template-columns: 1fr; } }
+    .tp-summary__pill {
+        padding: 0.875rem 1rem;
+        border-radius: 0.625rem;
+        background: rgba(0, 51, 127, 0.04);
+        border: 1px solid rgba(0, 51, 127, 0.1);
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+    }
+    html:not(.light-mode) .tp-summary__pill {
+        background: rgba(91, 154, 255, 0.04);
+        border-color: rgba(91, 154, 255, 0.12);
+    }
+    .tp-summary__label { font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-muted); font-family: 'IBM Plex Mono', monospace; }
+    .tp-summary__value { font-size: 1.375rem; font-weight: 700; color: var(--text-primary); }
+    .tp-summary__bar {
+        height: 4px;
+        border-radius: 999px;
+        background: rgba(0, 51, 127, 0.08);
+        overflow: hidden;
+        margin-top: 0.45rem;
+    }
+    html:not(.light-mode) .tp-summary__bar { background: rgba(255, 255, 255, 0.06); }
+    .tp-summary__fill {
+        height: 100%;
+        background: linear-gradient(90deg, #00337F, #0055cc);
+        border-radius: 999px;
+        transition: width 300ms ease;
+    }
+    html:not(.light-mode) .tp-summary__fill {
+        background: linear-gradient(90deg, #5b9aff, #8fb8ff);
+    }
+
+    .tp-subhead {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-family: 'IBM Plex Mono', monospace;
+        color: var(--text-muted);
+        margin: 1.5rem 0 0.75rem;
+        padding-left: 0.625rem;
+        border-left: 2px solid var(--thw-blue);
+    }
+    html:not(.light-mode) .tp-subhead { border-left-color: var(--thw-blue-glow, #5b9aff); }
+
+    .tp-section {
+        border: 1px solid rgba(0, 51, 127, 0.1);
+        border-radius: 0.625rem;
+        margin-bottom: 0.5rem;
+        overflow: hidden;
+        background: rgba(255, 255, 255, 0.3);
+    }
+    html:not(.light-mode) .tp-section {
+        border-color: rgba(255, 255, 255, 0.06);
+        background: rgba(255, 255, 255, 0.02);
+    }
+    .tp-section__head {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.75rem 0.875rem;
+        cursor: pointer;
+        user-select: none;
+        transition: background 200ms;
+    }
+    .tp-section__head:hover { background: rgba(0, 51, 127, 0.03); }
+    html:not(.light-mode) .tp-section__head:hover { background: rgba(91, 154, 255, 0.04); }
+
+    .tp-section__nr {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.6875rem;
+        font-weight: 700;
+        padding: 0.2rem 0.5rem;
+        border-radius: 0.25rem;
+        background: rgba(0, 51, 127, 0.08);
+        color: #00337F;
+        letter-spacing: 0.04em;
+        flex-shrink: 0;
+    }
+    html:not(.light-mode) .tp-section__nr {
+        background: rgba(91, 154, 255, 0.12);
+        color: #5b9aff;
+    }
+    .tp-section__title {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: var(--text-primary);
+        flex: 1;
+        min-width: 0;
+    }
+    .tp-section__meta {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        font-family: 'IBM Plex Mono', monospace;
+        flex-shrink: 0;
+    }
+    .tp-section__chev {
+        font-size: 0.875rem;
+        color: var(--text-muted);
+        transition: transform 250ms;
+        flex-shrink: 0;
+    }
+    .tp-section.is-open .tp-section__chev { transform: rotate(90deg); }
+
+    .tp-section__body {
+        padding: 0.25rem 0.875rem 0.75rem;
+        border-top: 1px solid rgba(0, 51, 127, 0.06);
+        display: none;
+    }
+    html:not(.light-mode) .tp-section__body { border-top-color: rgba(255, 255, 255, 0.04); }
+    .tp-section.is-open .tp-section__body { display: block; }
+
+    .tp-check {
+        display: flex;
+        align-items: center;
+        gap: 0.625rem;
+        padding: 0.5rem 0.25rem;
+        cursor: pointer;
+        border-radius: 0.375rem;
+        transition: background 200ms;
+    }
+    .tp-check:hover { background: rgba(0, 51, 127, 0.03); }
+    html:not(.light-mode) .tp-check:hover { background: rgba(91, 154, 255, 0.04); }
+
+    .tp-check input[type="checkbox"] {
+        appearance: none;
+        -webkit-appearance: none;
+        width: 18px;
+        height: 18px;
+        border-radius: 4px;
+        border: 1.5px solid rgba(0, 51, 127, 0.3);
+        background: var(--bg-elevated);
+        cursor: pointer;
+        position: relative;
+        flex-shrink: 0;
+        transition: all 150ms;
+    }
+    html:not(.light-mode) .tp-check input[type="checkbox"] {
+        border-color: rgba(91, 154, 255, 0.25);
+        background: #1a1a1d;
+    }
+    .tp-check input[type="checkbox"]:hover { border-color: var(--thw-blue); }
+    .tp-check input[type="checkbox"]:checked {
+        background: var(--thw-blue);
+        border-color: var(--thw-blue);
+    }
+    html:not(.light-mode) .tp-check input[type="checkbox"]:checked {
+        background: var(--thw-blue-glow, #5b9aff);
+        border-color: var(--thw-blue-glow, #5b9aff);
+    }
+    .tp-check input[type="checkbox"]:checked::after {
+        content: '';
+        position: absolute;
+        top: 2px; left: 5px;
+        width: 5px; height: 9px;
+        border: solid #fff;
+        border-width: 0 2px 2px 0;
+        transform: rotate(45deg);
+    }
+    .tp-check input[type="checkbox"]:indeterminate {
+        background: var(--thw-blue);
+        border-color: var(--thw-blue);
+    }
+    html:not(.light-mode) .tp-check input[type="checkbox"]:indeterminate {
+        background: var(--thw-blue-glow, #5b9aff);
+        border-color: var(--thw-blue-glow, #5b9aff);
+    }
+    .tp-check input[type="checkbox"]:indeterminate::after {
+        content: '';
+        position: absolute;
+        top: 7px; left: 3px;
+        width: 10px; height: 2px;
+        background: #fff;
+        border-radius: 1px;
+    }
+    .tp-check input[type="checkbox"]:disabled {
+        opacity: 0.6;
+        cursor: wait;
+    }
+    .tp-check__label {
+        font-size: 0.8125rem;
+        color: var(--text-primary);
+        line-height: 1.4;
+    }
+    .tp-check.is-done .tp-check__label {
+        color: var(--text-muted);
+        text-decoration: line-through;
+    }
+
+    .tp-zusatz-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 0.25rem;
+    }
+    @media (max-width: 640px) { .tp-zusatz-grid { grid-template-columns: 1fr; } }
+</style>
+@endpush
+
+@section('content')
+<div class="dash-container">
+
+    <div class="mm-head">
+        <img src="{{ $member->avatar_url }}" alt="" class="mm-head__avatar">
+        <div class="mm-head__text">
+            <div class="mm-head__eyebrow">Mitglied verwalten &middot; {{ $ortsverband->name }}</div>
+            <h1 class="mm-head__name">{{ $member->name }}</h1>
+            <div class="mm-head__email">{{ $member->email }}</div>
+        </div>
+        <a href="{{ route('ortsverband.members', $ortsverband) }}" class="btn-ghost btn-sm" style="text-decoration:none;">
+            Zurück
+        </a>
+    </div>
+
+    @if(session('success'))
+    <div class="glass p-4" style="border-radius:0.75rem;margin-bottom:1rem;display:flex;align-items:center;gap:0.75rem;border-left:3px solid #22c55e;">
+        <i class="bi bi-check-circle" style="color:#22c55e;font-size:1.1rem;flex-shrink:0;"></i>
+        <span style="font-size:0.875rem;color:var(--text-primary);flex:1;">{{ session('success') }}</span>
+    </div>
+    @endif
+
+    {{-- Stats Summary --}}
+    <div class="glass tp-card" style="margin-bottom: 1rem;">
+        <div class="tp-subhead" style="margin-top:0;">Fragen &amp; Prüfungen</div>
+        <div class="mm-stats">
+            <div class="mm-stat">
+                <span class="mm-stat__label">Gemeisterte Fragen</span>
+                <span class="mm-stat__value">{{ $stats['mastered_count'] }}/{{ $stats['total_questions'] }}</span>
+                <span class="mm-stat__meta">{{ $stats['mastered_percent'] }}% der Theorie</span>
+            </div>
+            <div class="mm-stat">
+                <span class="mm-stat__label">Beantwortet</span>
+                <span class="mm-stat__value">{{ number_format($stats['answered_total'], 0, ',', '.') }}</span>
+                <span class="mm-stat__meta">{{ number_format($stats['answered_correct'], 0, ',', '.') }} richtig &middot; {{ $stats['accuracy_percent'] }}%</span>
+            </div>
+            <div class="mm-stat">
+                <span class="mm-stat__label">Prüfungen</span>
+                <span class="mm-stat__value">{{ $stats['exams_passed'] }}/{{ $stats['exams_total'] }}</span>
+                <span class="mm-stat__meta">bestanden</span>
+            </div>
+            <div class="mm-stat">
+                <span class="mm-stat__label">Prüfungs-Streak</span>
+                <span class="mm-stat__value">{{ $stats['exam_streak'] }}</span>
+                <span class="mm-stat__meta">
+                    @if($stats['last_exam'])
+                        zuletzt {{ \Carbon\Carbon::parse($stats['last_exam']->created_at)->diffForHumans() }}
+                    @else
+                        noch keine Prüfung
+                    @endif
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <div class="glass tp-card" x-data="ausbilderTrainingProgress({
+        completed: @js($trainingOverview['completed_keys']),
+        overview: @js($trainingOverview),
+        lernabschnitte: @js($trainingLernabschnitte),
+        zusatz: @js($trainingZusatzausbildungen),
+        csrfToken: @js(csrf_token()),
+        itemUrl: @js(route('ortsverband.members.training.item', [$ortsverband, $member])),
+        sectionUrl: @js(route('ortsverband.members.training.section', [$ortsverband, $member]))
+    })">
+        <div class="tp-subhead" style="margin-top:0;">Ausbildungsfortschritt</div>
+
+        <div class="tp-summary">
+            <div class="tp-summary__pill">
+                <span class="tp-summary__label">Lernabschnitte</span>
+                <span class="tp-summary__value"><span x-text="overview.la_done"></span> / <span x-text="overview.la_total"></span></span>
+                <div class="tp-summary__bar"><div class="tp-summary__fill" :style="'width: ' + overview.la_percent + '%'"></div></div>
+            </div>
+            <div class="tp-summary__pill">
+                <span class="tp-summary__label">Zusatzausbildungen</span>
+                <span class="tp-summary__value"><span x-text="overview.zusatz_done"></span> / <span x-text="overview.zusatz_total"></span></span>
+                <div class="tp-summary__bar"><div class="tp-summary__fill" :style="'width: ' + overview.zusatz_percent + '%'"></div></div>
+            </div>
+            <div class="tp-summary__pill">
+                <span class="tp-summary__label">Gesamt</span>
+                <span class="tp-summary__value"><span x-text="overview.percent"></span>%</span>
+                <div class="tp-summary__bar"><div class="tp-summary__fill" :style="'width: ' + overview.percent + '%'"></div></div>
+            </div>
+        </div>
+
+        <div class="tp-subhead">Lernabschnitte</div>
+        <template x-for="la in lernabschnitte" :key="la.key">
+            <div class="tp-section" :id="la.key" :class="{ 'is-open': openSections[la.key] }">
+                <div class="tp-section__head" @click="openSections[la.key] = !openSections[la.key]">
+                    <label class="tp-check" style="padding: 0; margin: 0;" @click.stop>
+                        <input type="checkbox"
+                               :checked="sectionState(la).allDone"
+                               x-effect="$el.indeterminate = sectionState(la).someDone && !sectionState(la).allDone"
+                               :disabled="!!busy[la.key]"
+                               @change="toggleSection(la, $event.target.checked)">
+                    </label>
+                    <span class="tp-section__nr" x-text="la.nr"></span>
+                    <span class="tp-section__title" x-text="la.title"></span>
+                    <span class="tp-section__meta" x-text="sectionState(la).doneCount + '/' + la.items.length"></span>
+                    <i class="bi bi-chevron-right tp-section__chev"></i>
+                </div>
+                <div class="tp-section__body">
+                    <template x-for="item in la.items" :key="item.key">
+                        <label class="tp-check" :class="{ 'is-done': isDone(item.key) }">
+                            <input type="checkbox"
+                                   :checked="isDone(item.key)"
+                                   :disabled="!!busy[item.key]"
+                                   @change="toggleItem(item.key, $event.target.checked)">
+                            <span class="tp-check__label" x-text="item.label"></span>
+                        </label>
+                    </template>
+                </div>
+            </div>
+        </template>
+
+        <div class="tp-subhead">Zusatzausbildungen</div>
+        <div class="tp-zusatz-grid">
+            <template x-for="item in zusatz" :key="item.key">
+                <label class="tp-check" :class="{ 'is-done': isDone(item.key) }">
+                    <input type="checkbox"
+                           :checked="isDone(item.key)"
+                           :disabled="!!busy[item.key]"
+                           @change="toggleItem(item.key, $event.target.checked)">
+                    <span class="tp-check__label" x-text="item.label"></span>
+                </label>
+            </template>
+        </div>
+    </div>
+</div>
+
+<script>
+    function ausbilderTrainingProgress(config) {
+        return {
+            completedSet: (config.completed || []).reduce(function(acc, k) { acc[k] = true; return acc; }, {}),
+            overview: config.overview,
+            lernabschnitte: config.lernabschnitte,
+            zusatz: config.zusatz,
+            csrfToken: config.csrfToken,
+            itemUrl: config.itemUrl,
+            sectionUrl: config.sectionUrl,
+            openSections: {},
+            busy: {},
+
+            isDone(key) {
+                return !!this.completedSet[key];
+            },
+
+            sectionState(la) {
+                var done = 0;
+                for (var i = 0; i < la.items.length; i++) {
+                    if (this.completedSet[la.items[i].key]) done++;
+                }
+                return {
+                    doneCount: done,
+                    allDone: done === la.items.length && la.items.length > 0,
+                    someDone: done > 0,
+                };
+            },
+
+            async toggleItem(key, checked) {
+                if (this.busy[key]) return;
+                this.busy[key] = true;
+                var prev = !!this.completedSet[key];
+                this.completedSet[key] = !!checked;
+                try {
+                    var res = await fetch(this.itemUrl, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Accept': 'application/json',
+                            'X-CSRF-TOKEN': this.csrfToken,
+                        },
+                        body: JSON.stringify({ item_key: key, completed: !!checked }),
+                        cache: 'no-store',
+                    });
+                    var data = await res.json();
+                    if (data && data.success && data.overview) {
+                        this.overview = data.overview;
+                    } else {
+                        this.completedSet[key] = prev;
+                    }
+                } catch (e) {
+                    console.error('Training toggle error:', e);
+                    this.completedSet[key] = prev;
+                } finally {
+                    this.busy[key] = false;
+                }
+            },
+
+            async toggleSection(la, checked) {
+                if (this.busy[la.key]) return;
+                this.busy[la.key] = true;
+                var prev = {};
+                for (var i = 0; i < la.items.length; i++) {
+                    var k = la.items[i].key;
+                    prev[k] = !!this.completedSet[k];
+                    this.completedSet[k] = !!checked;
+                }
+                try {
+                    var res = await fetch(this.sectionUrl, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Accept': 'application/json',
+                            'X-CSRF-TOKEN': this.csrfToken,
+                        },
+                        body: JSON.stringify({ section_key: la.key, completed: !!checked }),
+                        cache: 'no-store',
+                    });
+                    var data = await res.json();
+                    if (data && data.success && data.overview) {
+                        this.overview = data.overview;
+                    } else {
+                        for (var j = 0; j < la.items.length; j++) {
+                            this.completedSet[la.items[j].key] = prev[la.items[j].key];
+                        }
+                    }
+                } catch (e) {
+                    console.error('Training section toggle error:', e);
+                    for (var j = 0; j < la.items.length; j++) {
+                        this.completedSet[la.items[j].key] = prev[la.items[j].key];
+                    }
+                } finally {
+                    this.busy[la.key] = false;
+                }
+            },
+        };
+    }
+</script>
+@endsection

--- a/resources/views/ortsverband/show.blade.php
+++ b/resources/views/ortsverband/show.blade.php
@@ -321,6 +321,9 @@
                         <div style="font-weight:600;font-size:0.8125rem;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ $member->name }}</div>
                         <div style="font-size:0.625rem;color:var(--text-muted);">{{ $member->pivot->role === 'ausbildungsbeauftragter' ? 'Ausbilder' : 'Mitglied' }}</div>
                     </div>
+                    @if($member->id !== auth()->id())
+                        <a href="{{ route('ortsverband.members.manage', [$ortsverband, $member]) }}" class="btn-ghost btn-sm" style="text-decoration:none;flex-shrink:0;">Verwalten</a>
+                    @endif
                 </div>
                 @endforeach
             @else
@@ -381,7 +384,7 @@
             </div>
             <div style="font-size:0.875rem;font-weight:600;color:var(--text-primary);margin-bottom:0.375rem;">Was sehen Ausbilder?</div>
             <p style="font-size:0.75rem;color:var(--text-muted);margin:0;line-height:1.5;">
-                Theorie-Fortschritt, Prüfungs-Streak, Lern-Streak, Level & Punkte, letzte Aktivität und Schwachstellen.
+                Ausbildungsfortschritt, Theorie-Fortschritt, Prüfungs-Streak, Lern-Streak, Level & Punkte, letzte Aktivität und Schwachstellen.
             </p>
         </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -725,6 +725,9 @@ Route::middleware('auth')->group(function () {
 
             // Mitglieder verwalten
             Route::get('/{ortsverband}/members', [\App\Http\Controllers\OrtsverbandController::class, 'members'])->name('members');
+            Route::get('/{ortsverband}/members/{user}/manage', [\App\Http\Controllers\OrtsverbandController::class, 'manageMember'])->name('members.manage');
+            Route::post('/{ortsverband}/members/{user}/training-item', [\App\Http\Controllers\OrtsverbandController::class, 'toggleMemberTrainingItem'])->name('members.training.item');
+            Route::post('/{ortsverband}/members/{user}/training-section', [\App\Http\Controllers\OrtsverbandController::class, 'toggleMemberTrainingSection'])->name('members.training.section');
             Route::delete('/{ortsverband}/members/{user}', [\App\Http\Controllers\OrtsverbandController::class, 'removeMember'])->name('members.remove');
             Route::put('/{ortsverband}/members/{user}/role', [\App\Http\Controllers\OrtsverbandController::class, 'changeRole'])->name('members.role');
 


### PR DESCRIPTION
Neuer "Verwalten"-Link zu Prüflings-Fortschritt
<img width="1974" height="2619" alt="localhost_8000_ortsverband_1" src="https://github.com/user-attachments/assets/d320e2d6-ad9d-4913-869e-6a923e072946" />
Aufteilung des Fortschritts in Theoriefragen/-Prüfungen und Ausbildungsfortschritt
<img width="1985" height="3065" alt="localhost_8000_ortsverband_1_dashboard" src="https://github.com/user-attachments/assets/3be7bbb5-9cef-417b-9d49-a176d0467708" />
Ansicht des Fortschritts in Theoriefragen/-Prüfungen und Ausbildungsfortschritt 
<img width="1973" height="3331" alt="localhost_8000_ortsverband_1_members_4_manage" src="https://github.com/user-attachments/assets/38f7c4bf-9532-4dc1-8328-ccac071a828f" />
Kombinierter View von Fortschritten und "Verwalten"
<img width="1977" height="2671" alt="localhost_8000_ortsverband_1_members" src="https://github.com/user-attachments/assets/c694e743-8ce9-45c9-906d-bd4b212fe3f3" />
