### PR TITLE
Refactor profile page: split settings into dedicated page

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -104,13 +104,13 @@ class ProfileController extends Controller
                 \Log::error('Failed to send email verification: ' . $e->getMessage());
             }
 
-            return Redirect::route('profile')->with('status', 'email-verification-sent');
+            return Redirect::route('einstellungen')->with('status', 'email-verification-sent');
         }
 
         $user->save();
         \Log::info('User profile updated successfully');
 
-        return Redirect::route('profile')->with('status', 'profile-updated');
+        return Redirect::route('einstellungen')->with('status', 'profile-updated');
     }
 
     /**
@@ -211,7 +211,7 @@ class ProfileController extends Controller
 
         \Log::info('Password updated for user: ' . $user->id);
 
-        return Redirect::route('profile')->with('status', 'password-updated');
+        return Redirect::route('einstellungen')->with('status', 'password-updated');
     }
 
     /**
@@ -227,7 +227,7 @@ class ProfileController extends Controller
         $user->extras_enabled = $request->boolean('extras_enabled');
         $user->save();
 
-        return Redirect::route('profile')
+        return Redirect::route('einstellungen')
             ->with('status', 'extras-enabled-updated');
     }
 
@@ -420,7 +420,7 @@ class ProfileController extends Controller
             $user->save();
         }
 
-        return Redirect::route('profile')->with('status', 'email-change-cancelled');
+        return Redirect::route('einstellungen')->with('status', 'email-change-cancelled');
     }
 
     /**

--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -43,6 +43,19 @@ class StatisticsController extends Controller
             ->selectRaw('questions.lernabschnitt, COUNT(*) as cnt, SUM(question_statistics.is_correct) as correct_cnt')
             ->groupBy('questions.lernabschnitt')->get()->keyBy('lernabschnitt');
 
+        $sectionNames = [
+            1 => 'Das THW im Gefüge des Zivil- und Katastrophenschutzes',
+            2 => 'Arbeitssicherheit und Gesundheitsschutz',
+            3 => 'Arbeiten mit Leinen, Drahtseilen, Ketten, Rund- und Bandschlingen',
+            4 => 'Arbeiten mit Leitern',
+            5 => 'Stromerzeugung und Beleuchtung',
+            6 => 'Metall-, Holz- und Steinbearbeitung',
+            7 => 'Bewegen von Lasten',
+            8 => 'Arbeiten am und auf dem Wasser',
+            9 => 'Einsatzgrundlagen',
+            10 => 'Grundlagen der Rettung und Bergung',
+        ];
+
         $sectionStats = [];
         for ($s = 1; $s <= 10; $s++) {
             $total = $questionsBySection[$s] ?? 0;
@@ -52,12 +65,15 @@ class StatisticsController extends Controller
 
             $sectionStats[] = [
                 'section' => $s,
+                'name' => $sectionNames[$s] ?? "Abschnitt {$s}",
                 'total' => $total,
                 'mastered' => $mastered,
                 'percent' => $total > 0 ? round(($mastered / $total) * 100) : 0,
                 'hit_rate' => $answered > 0 ? round(($correct / $answered) * 100) : 0,
             ];
         }
+
+        $topSections = collect($sectionStats)->sortByDesc('mastered')->take(3)->values()->all();
 
         // Activity (last 30 days)
         $activity = QuestionStatistic::where('user_id', $user->id)
@@ -92,11 +108,23 @@ class StatisticsController extends Controller
             ->orderBy('review_interval')
             ->get();
 
+        // 28-Tage Intensity-Heatmap (für Streak-Card)
+        $heatPattern = [];
+        for ($i = 0; $i < 28; $i++) {
+            $date = now()->subDays(27 - $i)->format('Y-m-d');
+            $dayData = $activity->get($date);
+            $count = (int) ($dayData->count ?? 0);
+            $intensity = $count === 0 ? 0 : ($count >= 20 ? 4 : ($count >= 10 ? 3 : ($count >= 5 ? 2 : 1)));
+            $heatPattern[] = $intensity;
+        }
+        $streakDays = $user->streak_days ?? 0;
+
         return view('statistics', compact(
             'totalQuestions', 'solvedTotal', 'masteredTotal',
             'progressPercent', 'masteryPercent', 'hitRate',
-            'sectionStats', 'activity', 'weeklyActivity',
-            'examHistory', 'srStats', 'intervalDistribution'
+            'sectionStats', 'topSections', 'activity', 'weeklyActivity',
+            'examHistory', 'srStats', 'intervalDistribution',
+            'heatPattern', 'streakDays'
         ));
     }
 }

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -44,7 +44,7 @@
                 </form>
 
                 @if(isset($pendingEmail))
-                    <form method="POST" action="{{ route('profile.cancel-email-change') }}">
+                    <form method="POST" action="{{ route('einstellungen.cancel-email-change') }}">
                         @csrf
                         <button type="submit" class="auth-ghost-btn">Abbrechen</button>
                     </form>

--- a/resources/views/einstellungen.blade.php
+++ b/resources/views/einstellungen.blade.php
@@ -1,0 +1,692 @@
+@extends('layouts.app')
+
+@section('title', 'Einstellungen - THW Trainer')
+@section('description', 'Verwalte dein Konto, Benachrichtigungen, Datenschutz und Sicherheit.')
+
+@push('styles')
+<style>
+    .dash-container { max-width: 1180px; padding: 0 1rem; }
+
+    .pf-page-title { margin-bottom: 1.5rem; }
+    .pf-page-title__eyebrow { font-family: 'IBM Plex Mono', monospace; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted); margin-bottom: 0.25rem; }
+    .pf-page-title__h1 { font-family: 'Barlow Condensed', 'Figtree', sans-serif; font-weight: 800; font-size: 2rem; line-height: 1.1; color: var(--text-primary); margin: 0 0 0.25rem; letter-spacing: -0.02em; }
+    html.light-mode .pf-page-title__h1 { color: var(--thw-blue, #00337F); }
+    .pf-page-title__sub { font-size: 0.875rem; color: var(--text-secondary); }
+
+    .bento { display: grid; grid-template-columns: repeat(12, 1fr); gap: 1rem; margin-top: 1rem; }
+    .bento > .card-account       { grid-column: span 6; }
+    .bento > .card-exam          { grid-column: span 6; }
+    .bento > .card-notifications { grid-column: span 6; }
+    .bento > .card-privacy       { grid-column: span 6; }
+    .bento > .card-security      { grid-column: span 6; }
+    .bento > .card-meta          { grid-column: span 12; }
+    .bento > .card-danger        { grid-column: span 12; }
+
+    @media (max-width: 1024px) {
+        .bento > .card-account, .bento > .card-exam, .bento > .card-notifications,
+        .bento > .card-privacy, .bento > .card-security { grid-column: span 12; }
+    }
+
+    .card { padding: 1.25rem; border-radius: 0.75rem; }
+    .card-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; gap: 1rem; }
+    .card-head .section-label { flex: 1; min-width: 0; }
+    .card-head__hint { font-size: 0.75rem; color: var(--text-muted); }
+
+    .section-label { font-family: 'IBM Plex Mono', monospace; font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); }
+    html.light-mode .section-label { color: #6b7280; }
+
+    .field { display: block; margin-bottom: 1rem; }
+    .field:last-child { margin-bottom: 0; }
+    .field__label { display: block; font-size: 0.8125rem; font-weight: 600; color: var(--text-primary); margin-bottom: 0.375rem; }
+    .field__help { font-size: 0.75rem; color: var(--text-muted); margin-top: 0.375rem; }
+    .field__error { font-size: 0.75rem; color: #ef4444; margin-top: 0.3rem; }
+    .field__row { display: flex; gap: 0.5rem; align-items: stretch; }
+    .field__row > .input { flex: 1; }
+
+    .input { width: 100%; padding: 0.625rem 0.75rem; border-radius: 0.5rem; border: 1px solid rgba(0,51,127,0.14); background: var(--bg-elevated, #fff); color: var(--text-primary); font-family: 'Figtree', system-ui, sans-serif; font-size: 0.9375rem; line-height: 1.35; transition: border-color 150ms ease, box-shadow 150ms ease; }
+    html:not(.light-mode) .input { background: #121214; border-color: rgba(255,255,255,0.1); }
+    .input:hover { border-color: rgba(0,51,127,0.25); }
+    html:not(.light-mode) .input:hover { border-color: rgba(91,154,255,0.35); }
+    .input:focus { outline: none; border-color: #00337F; box-shadow: 0 0 0 3px rgba(0,51,127,0.12); }
+    html:not(.light-mode) .input:focus { border-color: #5b9aff; box-shadow: 0 0 0 3px rgba(91,154,255,0.20); }
+    .input--error { border-color: #ef4444 !important; box-shadow: 0 0 0 2px rgba(239,68,68,0.15) !important; }
+
+    .toggle-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; padding: 0.75rem 0; border-bottom: 1px solid rgba(0,51,127,0.06); }
+    html:not(.light-mode) .toggle-row { border-bottom-color: rgba(255,255,255,0.06); }
+    .toggle-row:last-child { border-bottom: 0; padding-bottom: 0; }
+    .toggle-row:first-child { padding-top: 0; }
+    .toggle-row__body { flex: 1; min-width: 0; }
+    .toggle-row__title { font-size: 0.875rem; font-weight: 600; color: var(--text-primary); display: flex; align-items: center; gap: 0.5rem; }
+    .toggle-row__desc { font-size: 0.75rem; color: var(--text-muted); margin-top: 0.25rem; line-height: 1.5; }
+
+    .switch { position: relative; display: inline-block; width: 40px; height: 22px; flex-shrink: 0; }
+    .switch input { opacity: 0; width: 0; height: 0; position: absolute; }
+    .switch__slider { position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,51,127,0.15); border-radius: 999px; transition: background 150ms ease; }
+    html:not(.light-mode) .switch__slider { background: rgba(255,255,255,0.12); }
+    .switch__slider::before { content: ''; position: absolute; height: 16px; width: 16px; left: 3px; top: 3px; background: #fff; border-radius: 50%; transition: transform 150ms ease; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+    .switch input:checked + .switch__slider { background: #00337F; }
+    html:not(.light-mode) .switch input:checked + .switch__slider { background: #5b9aff; }
+    .switch input:checked + .switch__slider::before { transform: translateX(18px); }
+    .switch input:disabled + .switch__slider { cursor: not-allowed; opacity: 0.45; }
+    .switch--mini { width: 32px; height: 18px; }
+    .switch--mini .switch__slider::before { height: 12px; width: 12px; left: 3px; top: 3px; }
+    .switch--mini input:checked + .switch__slider::before { transform: translateX(14px); }
+
+    .notif-master { display: flex; flex-direction: column; }
+    .notif-categories { margin-top: 1rem; padding-top: 0.75rem; border-top: 1px solid rgba(0,51,127,0.08); }
+    html:not(.light-mode) .notif-categories { border-top-color: rgba(255,255,255,0.08); }
+    .notif-categories__header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.25rem; }
+    .notif-categories__label { font-size: 0.7rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-muted); }
+    .notif-categories__legend { display: flex; gap: 0.875rem; font-size: 0.85rem; color: var(--text-muted); padding-right: 0.25rem; }
+    .notif-categories__legend span { display: inline-flex; align-items: center; justify-content: center; width: 32px; }
+    .notif-cat-switches { display: flex; gap: 0.625rem; align-items: center; }
+    .notif-cat-row.is-saving { opacity: 0.6; pointer-events: none; }
+
+    .meta-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+    @media (max-width: 720px) { .meta-grid { grid-template-columns: 1fr; } }
+    .meta-item__label { font-family: 'IBM Plex Mono', monospace; font-size: 0.6875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted); margin-bottom: 0.25rem; }
+    .meta-item__value { font-size: 0.9375rem; font-weight: 600; color: var(--text-primary); }
+    .meta-item__sub { font-size: 0.75rem; color: var(--text-muted); margin-top: 0.1rem; }
+
+    .danger-card { padding: 1.25rem; border: 1px solid rgba(239,68,68,0.3); background: rgba(239,68,68,0.04); border-radius: 0.75rem; }
+    html:not(.light-mode) .danger-card { background: rgba(239,68,68,0.08); }
+    .danger-card .section-label { color: #ef4444; }
+    .danger-head { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem; }
+    .danger-icon { width: 36px; height: 36px; border-radius: 0.5rem; background: rgba(239,68,68,0.12); color: #ef4444; display: grid; place-items: center; font-size: 1.125rem; flex-shrink: 0; }
+    .danger-title { font-size: 1rem; font-weight: 700; color: var(--text-primary); }
+    .danger-desc { font-size: 0.8125rem; color: var(--text-secondary); margin-bottom: 1rem; line-height: 1.5; }
+
+    .btn-danger-inline { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.625rem 1rem; border-radius: 0.5rem; background: #ef4444; color: #fff; border: 0; font-family: 'Figtree', system-ui, sans-serif; font-weight: 700; font-size: 0.875rem; cursor: pointer; transition: background 150ms ease, box-shadow 150ms ease; }
+    .btn-danger-inline:hover { background: #dc2626; box-shadow: 0 4px 14px rgba(239,68,68,0.35); }
+    .btn-danger-inline:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .card-foot { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; margin-top: 1rem; padding-top: 1rem; border-top: 1px solid rgba(0,51,127,0.06); flex-wrap: wrap; }
+    html:not(.light-mode) .card-foot { border-top-color: rgba(255,255,255,0.06); }
+    .card-foot__note { font-size: 0.75rem; color: var(--text-muted); }
+
+    .btn-pf-primary { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.625rem 1.125rem; border-radius: 0.5rem; background: linear-gradient(135deg, #00337F, #0055cc); color: #fff; border: 0; font-family: 'Figtree', system-ui, sans-serif; font-weight: 700; font-size: 0.875rem; cursor: pointer; transition: box-shadow 150ms ease, transform 150ms ease; }
+    .btn-pf-primary:hover { box-shadow: 0 8px 25px rgba(0,51,127,0.45); transform: translateY(-1px); }
+
+    .btn-pf-ghost { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.5rem 0.875rem; border-radius: 0.5rem; background: transparent; color: var(--text-primary); border: 1px solid rgba(0,51,127,0.2); font-family: 'Figtree', system-ui, sans-serif; font-weight: 600; font-size: 0.875rem; cursor: pointer; transition: background 150ms ease, border-color 150ms ease; text-decoration: none; }
+    html:not(.light-mode) .btn-pf-ghost { border-color: rgba(255,255,255,0.1); }
+    .btn-pf-ghost:hover { background: rgba(0,51,127,0.05); border-color: rgba(0,51,127,0.35); }
+    html:not(.light-mode) .btn-pf-ghost:hover { background: rgba(91,154,255,0.1); border-color: rgba(91,154,255,0.35); }
+
+    .info-row { display: flex; gap: 0.75rem; padding: 0.875rem; margin: 0.25rem 0; border-radius: 0.5rem; background: rgba(0, 51, 127, 0.04); border: 1px solid rgba(0, 51, 127, 0.1); }
+    html:not(.light-mode) .info-row { background: rgba(91,154,255,0.08); border-color: rgba(91,154,255,0.2); }
+    .info-row__icon { width: 28px; height: 28px; border-radius: 50%; background: #00337F; color: #fff; display: grid; place-items: center; font-size: 0.8125rem; flex-shrink: 0; }
+    html:not(.light-mode) .info-row__icon { background: #5b9aff; }
+    .info-row__title { font-size: 0.875rem; font-weight: 600; color: var(--text-primary); margin-bottom: 0.2rem; }
+    .info-row__desc { font-size: 0.75rem; color: var(--text-secondary); line-height: 1.55; }
+
+    .link-row { display: flex; align-items: center; justify-content: space-between; padding: 0.75rem 0; border-bottom: 1px solid rgba(0,51,127,0.06); text-decoration: none; color: inherit; cursor: pointer; }
+    html:not(.light-mode) .link-row { border-bottom-color: rgba(255,255,255,0.06); }
+    .link-row:last-child { border-bottom: 0; }
+    .link-row__title { font-size: 0.875rem; font-weight: 600; color: var(--text-primary); }
+    .link-row__sub { font-size: 0.75rem; color: var(--text-muted); margin-top: 0.15rem; }
+
+    .is-locked { position: relative; }
+    .is-locked .card-body-locked { opacity: 0.42; pointer-events: none; user-select: none; }
+    .locked-badge { display: inline-flex; align-items: center; gap: 0.3rem; padding: 0.15rem 0.5rem; border-radius: 999px; background: rgba(91,154,255,0.12); border: 1px solid rgba(91,154,255,0.25); color: #5b9aff; font-family: 'IBM Plex Mono', monospace; font-size: 0.5625rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; }
+    html.light-mode .locked-badge { background: rgba(0,51,127,0.06); border-color: rgba(0,51,127,0.15); color: #00337F; }
+
+    .pf-pw-msg { font-size: 0.75rem; margin-top: 0.3rem; display: none; align-items: center; gap: 0.3rem; }
+
+    @keyframes pf-rise { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+    .bento > * { animation: pf-rise 0.45s cubic-bezier(0.22, 1, 0.36, 1) both; }
+    .bento > *:nth-child(1) { animation-delay: 0.03s; }
+    .bento > *:nth-child(2) { animation-delay: 0.07s; }
+    .bento > *:nth-child(3) { animation-delay: 0.11s; }
+    .bento > *:nth-child(4) { animation-delay: 0.15s; }
+    .bento > *:nth-child(5) { animation-delay: 0.19s; }
+    .bento > *:nth-child(6) { animation-delay: 0.23s; }
+    .bento > *:nth-child(7) { animation-delay: 0.27s; }
+    @media (prefers-reduced-motion: reduce) { .bento > * { animation: none; } }
+</style>
+@endpush
+
+@section('content')
+@php
+    $daysSince = (int) floor($user->created_at->diffInDays(now()));
+    $lastActive = $user->last_activity_at
+        ? (\Illuminate\Support\Carbon::parse($user->last_activity_at))
+        : ($user->last_login_at ?? null);
+    $notifCategories = [
+        'daily_reminder' => ['title' => 'Tägliche Lernerinnerung', 'desc' => 'Eine kurze Erinnerung, wenn du deinen Streak zu verlieren drohst.'],
+        'spaced_repetition' => ['title' => 'Spaced-Repetition-Reviews', 'desc' => 'Benachrichtigung, sobald Fragen zur Wiederholung fällig sind.'],
+        'league_updates' => ['title' => 'Liga- & Achievement-Updates', 'desc' => 'Wenn du aufsteigst, fällst oder ein neues Achievement freischaltest.'],
+    ];
+@endphp
+
+<div class="dash-container">
+
+    <div class="pf-page-title">
+        <div class="pf-page-title__eyebrow">Konto</div>
+        <h1 class="pf-page-title__h1">Einstellungen</h1>
+        <div class="pf-page-title__sub">Persönliche Daten, Benachrichtigungen, Datenschutz und Sicherheit.</div>
+    </div>
+
+    @if (session('status'))
+    <div class="alert-compact glass-success" style="margin-bottom: 1rem;">
+        <i class="bi bi-check-circle alert-compact-icon"></i>
+        <div class="alert-compact-content">
+            <div class="alert-compact-title">
+                @if(session('status') == 'profile-updated') Profil erfolgreich aktualisiert.
+                @elseif(session('status') == 'password-updated') Passwort erfolgreich geändert.
+                @elseif(session('status') == 'email-change-cancelled') E-Mail-Änderung abgebrochen.
+                @elseif(session('status') == 'extras-enabled-updated') Zusatz-Fragen-Einstellung gespeichert.
+                @elseif(session('status') == 'email-verification-sent') Bestätigungs-E-Mail wurde gesendet.
+                @else {{ session('status') }}
+                @endif
+            </div>
+        </div>
+        <button style="background:none;border:none;cursor:pointer;font-size:1.25rem;color:var(--text-secondary);" onclick="this.parentElement.remove()">&times;</button>
+    </div>
+    @endif
+
+    @if ($user->pending_email)
+    <div class="alert-compact glass-warning" style="margin-bottom: 1rem;">
+        <i class="bi bi-clock-history alert-compact-icon"></i>
+        <div class="alert-compact-content">
+            <div class="alert-compact-title">E-Mail-Änderung ausstehend</div>
+            <div class="alert-compact-desc">
+                Bestätigungscode gesendet an <strong>{{ $user->pending_email }}</strong>.
+                <a href="{{ route('verification.notice') }}" style="color:var(--gold);text-decoration:underline;">Jetzt bestätigen</a>
+                <form method="POST" action="{{ route('einstellungen.cancel-email-change') }}" style="display:inline;">
+                    @csrf
+                    <button type="submit" style="background:none;border:none;color:var(--text-secondary);text-decoration:underline;cursor:pointer;padding:0;font-size:inherit;">Abbrechen</button>
+                </form>
+            </div>
+        </div>
+    </div>
+    @endif
+
+    <div class="bento">
+
+        {{-- Persönliche Daten --}}
+        <div class="glass card-account card">
+            <div class="card-head">
+                <span class="section-label">Persönliche Daten</span>
+            </div>
+            <form method="POST" action="{{ route('einstellungen.update') }}" id="profile-main-form">
+                @csrf
+                @method('PATCH')
+                <div class="field">
+                    <label class="field__label" for="name">Name</label>
+                    <input class="input @error('name') input--error @enderror" type="text" id="name" name="name" value="{{ old('name', $user->name) }}" required maxlength="255">
+                    @error('name')
+                        <div class="field__error">{{ $message }}</div>
+                    @else
+                        <div class="field__help">Dieser Name erscheint im Leaderboard.</div>
+                    @enderror
+                </div>
+                <div class="field">
+                    <label class="field__label" for="email">E-Mail-Adresse</label>
+                    <input class="input @error('email') input--error @enderror" type="email" id="email" name="email" value="{{ old('email', $user->email) }}" required>
+                    @error('email')
+                        <div class="field__error">{{ $message }}</div>
+                    @else
+                        <div class="field__help">Änderungen erfordern eine Bestätigung per E-Mail.</div>
+                    @enderror
+                </div>
+                <div class="field">
+                    <label class="field__label">Ortsverband</label>
+                    @if(($ortsverbande ?? collect())->isNotEmpty())
+                        <div style="display:flex;flex-direction:column;gap:0.5rem;">
+                            @foreach($ortsverbande as $ov)
+                                <a href="{{ route('ortsverband.show', $ov) }}" style="display:flex;align-items:center;gap:0.75rem;padding:0.625rem 0.875rem;border:1px solid rgba(0,51,127,0.15);border-radius:10px;background:rgba(0,51,127,0.04);text-decoration:none;color:var(--text-primary);">
+                                    <i class="bi bi-building" style="color:var(--thw-blue);font-size:1.125rem;"></i>
+                                    <div style="flex:1;">
+                                        <div style="font-weight:600;font-size:0.9375rem;">{{ $ov->name }}</div>
+                                        @if($ov->pivot->role ?? null)
+                                            <div style="font-size:0.75rem;color:var(--text-muted);">{{ ucfirst($ov->pivot->role) }}</div>
+                                        @endif
+                                    </div>
+                                    <i class="bi bi-chevron-right" style="color:var(--text-muted);font-size:0.875rem;"></i>
+                                </a>
+                            @endforeach
+                        </div>
+                        <div class="field__help">Mitgliedschaften verwalten auf der Ortsverband-Seite.</div>
+                    @else
+                        <div style="padding:1rem;border:1px dashed rgba(0,51,127,0.2);border-radius:10px;background:rgba(0,51,127,0.03);text-align:center;">
+                            <div style="font-size:0.875rem;color:var(--text-secondary);margin-bottom:0.75rem;">Du bist noch keinem Ortsverband beigetreten.</div>
+                            <a href="{{ route('ortsverband.index') }}" class="btn-pf-primary" style="display:inline-flex;align-items:center;gap:0.5rem;">
+                                <i class="bi bi-plus-circle"></i> Ortsverband beitreten
+                            </a>
+                        </div>
+                    @endif
+                </div>
+                <input type="hidden" name="email_consent" value="{{ $user->email_consent ? 1 : 0 }}">
+                <input type="hidden" name="leaderboard_consent" value="{{ $user->leaderboard_consent ? 1 : 0 }}">
+                <input type="hidden" name="exam_date" value="{{ $user->exam_date?->format('Y-m-d') }}">
+                <div class="card-foot">
+                    <span class="card-foot__note">Änderungen werden nach dem Speichern aktiv.</span>
+                    <button class="btn-pf-primary" type="submit">Speichern</button>
+                </div>
+            </form>
+        </div>
+
+        {{-- Prüfung & Zusatz-Fragen --}}
+        <div class="glass card-exam card">
+            <div class="card-head">
+                <span class="section-label">Prüfung & Zusatz-Fragen</span>
+            </div>
+            <form method="POST" action="{{ route('einstellungen.update') }}" id="exam-date-form">
+                @csrf
+                @method('PATCH')
+                <input type="hidden" name="name" value="{{ $user->name }}">
+                <input type="hidden" name="email" value="{{ $user->email }}">
+                <input type="hidden" name="email_consent" value="{{ $user->email_consent ? 1 : 0 }}">
+                <input type="hidden" name="leaderboard_consent" value="{{ $user->leaderboard_consent ? 1 : 0 }}">
+                <div class="field">
+                    <label class="field__label" for="exam-date">Prüfungsdatum (optional)</label>
+                    <div class="field__row">
+                        <input class="input @error('exam_date') input--error @enderror" type="date" id="exam-date" name="exam_date"
+                               value="{{ old('exam_date', $user->exam_date?->format('Y-m-d')) }}"
+                               min="{{ date('Y-m-d', strtotime('+1 day')) }}">
+                        <button class="btn-pf-ghost" type="button" onclick="document.getElementById('exam-date').value=''">Zurücksetzen</button>
+                    </div>
+                    @error('exam_date')
+                        <div class="field__error">{{ $message }}</div>
+                    @else
+                        <div class="field__help">Für eine personalisierte Lernempfehlung auf dem Dashboard.</div>
+                    @enderror
+                </div>
+            </form>
+            <form method="POST" action="{{ route('einstellungen.extras-enabled') }}">
+                @csrf
+                <input type="hidden" name="extras_enabled" value="0">
+                <div class="toggle-row">
+                    <div class="toggle-row__body">
+                        <div class="toggle-row__title">Zusatz-Fragen aktivieren</div>
+                        <div class="toggle-row__desc">Zusätzliche außerhalb-der-Prüfung Übungsfragen. Erscheinen im Übungsmodus und beeinflussen nicht deine Prüfungsauswertung.</div>
+                    </div>
+                    <label class="switch">
+                        <input type="checkbox" name="extras_enabled" value="1" onchange="this.form.submit()" {{ $user->extras_enabled ? 'checked' : '' }}>
+                        <span class="switch__slider"></span>
+                    </label>
+                </div>
+            </form>
+            <div class="card-foot">
+                <span class="card-foot__note">Änderungen am Prüfungsdatum nach dem Speichern aktiv.</span>
+                <button class="btn-pf-primary" type="button" onclick="document.getElementById('exam-date-form').submit()">Speichern</button>
+            </div>
+        </div>
+
+        {{-- Benachrichtigungen --}}
+        <div class="glass card-notifications card" id="notif-card">
+            <div class="card-head">
+                <span class="section-label">Benachrichtigungen</span>
+                <span class="card-head__hint" id="notif-consent-hint">
+                    @if($user->email_consent_at && $user->push_consent_at)
+                        E-Mail seit {{ $user->email_consent_at->format('d.m.Y') }} · Push seit {{ $user->push_consent_at->format('d.m.Y') }}
+                    @elseif($user->email_consent_at)
+                        E-Mail seit {{ $user->email_consent_at->format('d.m.Y') }}
+                    @elseif($user->push_consent_at)
+                        Push seit {{ $user->push_consent_at->format('d.m.Y') }}
+                    @else
+                        Noch nicht aktiviert
+                    @endif
+                </span>
+            </div>
+            <div class="notif-master">
+                <div class="toggle-row notif-master-row">
+                    <div class="toggle-row__body">
+                        <div class="toggle-row__title">
+                            <i class="bi bi-envelope-fill" style="color: var(--thw-blue, #00337F);"></i>
+                            E-Mail-Benachrichtigungen
+                        </div>
+                        <div class="toggle-row__desc">Erhalte E-Mails zu Lernfortschritt, neuen Features und Systeminformationen.</div>
+                    </div>
+                    <label class="switch">
+                        <input type="checkbox" data-notif-master="email" {{ $user->email_consent ? 'checked' : '' }}>
+                        <span class="switch__slider"></span>
+                    </label>
+                </div>
+                <div class="toggle-row notif-master-row">
+                    <div class="toggle-row__body">
+                        <div class="toggle-row__title">
+                            <i class="bi bi-bell-fill" style="color: var(--thw-blue, #00337F);"></i>
+                            Push-Benachrichtigungen
+                        </div>
+                        <div class="toggle-row__desc">Browser- und App-Push für wichtige Updates direkt auf dein Gerät.</div>
+                    </div>
+                    <label class="switch">
+                        <input type="checkbox" data-notif-master="push" {{ $user->push_consent ? 'checked' : '' }}>
+                        <span class="switch__slider"></span>
+                    </label>
+                </div>
+            </div>
+            <div class="notif-categories">
+                <div class="notif-categories__header">
+                    <span class="notif-categories__label">Einzelne Benachrichtigungen</span>
+                    <div class="notif-categories__legend">
+                        <span title="E-Mail"><i class="bi bi-envelope"></i></span>
+                        <span title="Push"><i class="bi bi-bell"></i></span>
+                    </div>
+                </div>
+                @foreach($notifCategories as $key => $cat)
+                    <div class="toggle-row notif-cat-row">
+                        <div class="toggle-row__body">
+                            <div class="toggle-row__title">{{ $cat['title'] }}</div>
+                            <div class="toggle-row__desc">{{ $cat['desc'] }}</div>
+                        </div>
+                        <div class="notif-cat-switches">
+                            <label class="switch switch--mini" title="E-Mail">
+                                <input type="checkbox" data-notif-channel="email" data-notif-category="{{ $key }}"
+                                       {{ $user->{"notify_{$key}_email"} ? 'checked' : '' }}
+                                       {{ $user->email_consent ? '' : 'disabled' }}>
+                                <span class="switch__slider"></span>
+                            </label>
+                            <label class="switch switch--mini" title="Push">
+                                <input type="checkbox" data-notif-channel="push" data-notif-category="{{ $key }}"
+                                       {{ $user->{"notify_{$key}_push"} ? 'checked' : '' }}
+                                       {{ $user->push_consent ? '' : 'disabled' }}>
+                                <span class="switch__slider"></span>
+                            </label>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+
+        {{-- Privatsphäre & Datenschutz --}}
+        <div class="glass card-privacy card">
+            <div class="card-head">
+                <span class="section-label">Privatsphäre & Datenschutz</span>
+                <a href="/datenschutz" class="card-head__hint" style="color: var(--thw-blue, #00337F); text-decoration: none; font-weight: 600;">Datenschutzerklärung →</a>
+            </div>
+            <form method="POST" action="{{ route('einstellungen.update') }}" id="privacy-form">
+                @csrf
+                @method('PATCH')
+                <input type="hidden" name="name" value="{{ $user->name }}">
+                <input type="hidden" name="email" value="{{ $user->email }}">
+                <input type="hidden" name="email_consent" value="{{ $user->email_consent ? 1 : 0 }}">
+                <input type="hidden" name="exam_date" value="{{ $user->exam_date?->format('Y-m-d') }}">
+                <input type="hidden" name="leaderboard_consent" value="0">
+                <div class="toggle-row">
+                    <div class="toggle-row__body">
+                        <div class="toggle-row__title">Leaderboard-Teilnahme</div>
+                        <div class="toggle-row__desc">Dein Name erscheint im öffentlichen Leaderboard. Deaktivieren macht dein Konto anonym.</div>
+                    </div>
+                    <label class="switch">
+                        <input type="checkbox" name="leaderboard_consent" value="1" onchange="this.form.submit()" {{ $user->leaderboard_consent ? 'checked' : '' }}>
+                        <span class="switch__slider"></span>
+                    </label>
+                </div>
+            </form>
+            <div class="info-row">
+                <div class="info-row__icon"><i class="bi bi-info-circle-fill"></i></div>
+                <div class="info-row__body">
+                    <div class="info-row__title">Aggregierte Nutzungsstatistik</div>
+                    <div class="info-row__desc">
+                        Zur Produktverbesserung erheben wir ausschließlich <strong>aggregierte, anonyme Statistiken</strong>. Keine personenbezogenen Daten, keine Weitergabe an Dritte, kein externes Tracking.
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {{-- Sicherheit --}}
+        <div class="glass card-security card">
+            <div class="card-head">
+                <span class="section-label">Sicherheit</span>
+            </div>
+            <form method="POST" action="{{ route('einstellungen.password.update') }}">
+                @csrf
+                @method('PATCH')
+                <div class="field">
+                    <label class="field__label" for="current_password">Aktuelles Passwort</label>
+                    <input class="input @error('current_password') input--error @enderror" type="password" id="current_password" name="current_password" placeholder="Aktuelles Passwort">
+                    @error('current_password')<div class="field__error">{{ $message }}</div>@enderror
+                </div>
+                <div class="field">
+                    <label class="field__label" for="password">Neues Passwort</label>
+                    <input class="input @error('password') input--error @enderror" type="password" id="password" name="password" placeholder="Mindestens 8 Zeichen" oninput="checkPasswordMatch()">
+                    @error('password')<div class="field__error">{{ $message }}</div>@enderror
+                </div>
+                <div class="field">
+                    <label class="field__label" for="password_confirmation">Passwort bestätigen</label>
+                    <input class="input" type="password" id="password_confirmation" name="password_confirmation" placeholder="Passwort wiederholen" oninput="checkPasswordMatch()">
+                    <div id="password-match-message" class="pf-pw-msg"></div>
+                </div>
+                <div class="toggle-row is-locked">
+                    <div class="toggle-row__body card-body-locked">
+                        <div class="toggle-row__title">
+                            Zwei-Faktor-Authentifizierung (2FA)
+                            <span class="locked-badge"><i class="bi bi-lock"></i> Bald</span>
+                        </div>
+                        <div class="toggle-row__desc">Zusätzlicher Schutz per TOTP-App (z. B. Aegis, Authy). Empfohlen für Admin-Accounts.</div>
+                    </div>
+                    <label class="switch">
+                        <input type="checkbox" disabled>
+                        <span class="switch__slider"></span>
+                    </label>
+                </div>
+                <div class="card-foot">
+                    <span class="card-foot__note">Nach Passwortänderung bleibst du angemeldet.</span>
+                    <button class="btn-pf-primary" type="submit">Passwort ändern</button>
+                </div>
+            </form>
+        </div>
+
+        {{-- Konto-Details --}}
+        <div class="glass card-meta card">
+            <div class="card-head">
+                <span class="section-label">Konto-Details</span>
+            </div>
+            <div class="meta-grid">
+                <div class="meta-item">
+                    <div class="meta-item__label">Beitrittsdatum</div>
+                    <div class="meta-item__value">{{ $user->created_at->format('d.m.Y') }}</div>
+                    <div class="meta-item__sub">vor {{ $daysSince }} {{ $daysSince === 1 ? 'Tag' : 'Tagen' }}</div>
+                </div>
+                <div class="meta-item">
+                    <div class="meta-item__label">Konto-Status</div>
+                    @if($user->pending_email)
+                        <div class="meta-item__value" style="color: #f59e0b;">E-Mail-Änderung</div>
+                        <div class="meta-item__sub">Bestätigung an {{ $user->pending_email }}</div>
+                    @elseif($user->hasVerifiedEmail())
+                        <div class="meta-item__value" style="color: #22c55e;">Bestätigt</div>
+                        <div class="meta-item__sub">E-Mail verifiziert</div>
+                    @else
+                        <div class="meta-item__value" style="color: #f59e0b;">Ausstehend</div>
+                        <div class="meta-item__sub">E-Mail nicht verifiziert</div>
+                    @endif
+                </div>
+                <div class="meta-item">
+                    <div class="meta-item__label">Zuletzt aktiv</div>
+                    <div class="meta-item__value">{{ $lastActive ? $lastActive->diffForHumans() : 'Gerade eben' }}</div>
+                    <div class="meta-item__sub">{{ $lastActive ? $lastActive->format('d.m.Y H:i') : 'Erste Anmeldung' }}</div>
+                </div>
+            </div>
+        </div>
+
+        {{-- Danger Zone --}}
+        <div class="card-danger">
+            <div class="danger-card">
+                <div class="danger-head">
+                    <div class="danger-icon"><i class="bi bi-exclamation-triangle-fill"></i></div>
+                    <div>
+                        <span class="section-label">Danger Zone</span>
+                        <div class="danger-title">Account permanent löschen</div>
+                    </div>
+                </div>
+                <div class="danger-desc">
+                    Diese Aktion kann <strong>nicht rückgängig</strong> gemacht werden. Alle deine Daten — Antworten, Fortschritt, Achievements — werden unwiderruflich gelöscht (Art. 17 DSGVO · Recht auf Löschung).
+                </div>
+                <form method="POST" action="{{ route('einstellungen.destroy') }}"
+                      onsubmit="return confirm('Bist du dir absolut sicher? Alle deine Daten werden permanent gelöscht.')">
+                    @csrf
+                    @method('DELETE')
+                    <div class="field">
+                        <label class="field__label" for="password_delete">Passwort zur Bestätigung</label>
+                        <input class="input @error('password', 'userDeletion') input--error @enderror" type="password"
+                               id="password_delete" name="password" placeholder="Passwort eingeben" style="max-width: 320px;">
+                        @error('password', 'userDeletion')<div class="field__error">{{ $message }}</div>@enderror
+                    </div>
+                    <div style="display: flex; gap: 0.75rem; align-items: center; margin-top: 1rem; flex-wrap: wrap;">
+                        <button class="btn-danger-inline" type="submit"><i class="bi bi-trash3-fill"></i> Account permanent löschen</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<script>
+    function checkPasswordMatch() {
+        var pw = document.getElementById('password').value;
+        var confirm = document.getElementById('password_confirmation').value;
+        var msg = document.getElementById('password-match-message');
+        if (pw && confirm) {
+            var match = pw === confirm;
+            document.getElementById('password').classList.toggle('input--error', !match);
+            document.getElementById('password_confirmation').classList.toggle('input--error', !match);
+            msg.style.display = 'flex';
+            msg.style.color = match ? '#22c55e' : '#ef4444';
+            msg.innerHTML = '<i class="bi bi-' + (match ? 'check' : 'x') + '-circle"></i> Passwörter stimmen ' + (match ? 'überein' : 'nicht überein');
+        } else {
+            document.getElementById('password').classList.remove('input--error');
+            document.getElementById('password_confirmation').classList.remove('input--error');
+            msg.style.display = 'none';
+        }
+    }
+
+    (function () {
+        var card = document.getElementById('notif-card');
+        if (!card) return;
+        var csrf = document.querySelector('meta[name="csrf-token"]').content;
+        var endpoint = '{{ route("einstellungen.notification-preferences") }}';
+        var vapidPublicKey = @json(config('services.webpush.public_key'));
+
+        function setRowSaving(input, saving) {
+            var row = input.closest('.toggle-row');
+            if (row) row.classList.toggle('is-saving', saving);
+        }
+        function showToast(msg, type) {
+            var toast = document.createElement('div');
+            var bg = type === 'error' ? '#ef4444' : '#22c55e';
+            toast.style.cssText = 'position:fixed;bottom:1rem;right:1rem;background:' + bg + ';color:#fff;padding:0.75rem 1rem;border-radius:0.5rem;box-shadow:0 4px 12px rgba(0,0,0,0.2);z-index:9999;font-size:0.875rem;max-width:320px;';
+            toast.textContent = msg;
+            document.body.appendChild(toast);
+            setTimeout(function () { toast.remove(); }, 3500);
+        }
+        async function patch(payload) {
+            var res = await fetch(endpoint, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrf, 'Accept': 'application/json' },
+                body: JSON.stringify(payload),
+                cache: 'no-store',
+            });
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            return res.json();
+        }
+        function syncSubToggles(channel, masterEnabled, forceCheckAll) {
+            card.querySelectorAll('input[data-notif-channel="' + channel + '"]').forEach(function (input) {
+                input.disabled = !masterEnabled;
+                if (forceCheckAll && masterEnabled) input.checked = true;
+            });
+        }
+        function updateConsentHint() {
+            var hint = document.getElementById('notif-consent-hint');
+            if (!hint) return;
+            var emailMaster = card.querySelector('input[data-notif-master="email"]');
+            var pushMaster = card.querySelector('input[data-notif-master="push"]');
+            var parts = [];
+            if (emailMaster && emailMaster.checked) parts.push('E-Mail aktiv');
+            if (pushMaster && pushMaster.checked) parts.push('Push aktiv');
+            hint.textContent = parts.length ? parts.join(' · ') : 'Noch nicht aktiviert';
+        }
+        function urlBase64ToUint8Array(base64String) {
+            var padding = '='.repeat((4 - base64String.length % 4) % 4);
+            var base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+            var raw = atob(base64);
+            var arr = new Uint8Array(raw.length);
+            for (var i = 0; i < raw.length; ++i) arr[i] = raw.charCodeAt(i);
+            return arr;
+        }
+        async function enableBrowserPush() {
+            if (!('serviceWorker' in navigator) || !('PushManager' in window)) throw new Error('Push wird in diesem Browser nicht unterstützt.');
+            if (!vapidPublicKey) throw new Error('Push-Konfiguration fehlt (VAPID).');
+            var permission = await Notification.requestPermission();
+            if (permission !== 'granted') throw new Error('Du hast Push-Benachrichtigungen im Browser nicht erlaubt.');
+            var registration = await navigator.serviceWorker.register('/sw.js');
+            await navigator.serviceWorker.ready;
+            var subscription = await registration.pushManager.getSubscription();
+            if (!subscription) {
+                subscription = await registration.pushManager.subscribe({
+                    userVisibleOnly: true,
+                    applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+                });
+            }
+            var sub = subscription.toJSON();
+            await fetch('{{ route("push.subscribe") }}', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrf },
+                body: JSON.stringify({ endpoint: sub.endpoint, keys: sub.keys, content_encoding: 'aes128gcm' }),
+            });
+        }
+        async function disableBrowserPush() {
+            if (!('serviceWorker' in navigator)) return;
+            var registration = await navigator.serviceWorker.getRegistration();
+            if (!registration) return;
+            var subscription = await registration.pushManager.getSubscription();
+            if (!subscription) return;
+            var endpointUrl = subscription.endpoint;
+            try { await subscription.unsubscribe(); } catch (e) { console.warn(e); }
+            await fetch('{{ route("push.unsubscribe") }}', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrf },
+                body: JSON.stringify({ endpoint: endpointUrl }),
+            });
+        }
+
+        card.querySelectorAll('input[data-notif-master]').forEach(function (input) {
+            input.addEventListener('change', async function () {
+                var master = input.getAttribute('data-notif-master');
+                var enabled = input.checked;
+                setRowSaving(input, true);
+                try {
+                    if (master === 'push') {
+                        if (enabled) await enableBrowserPush();
+                        else await disableBrowserPush();
+                    }
+                    var data = await patch({ master: master, enabled: enabled });
+                    if (!data.success) throw new Error(data.message || 'Speichern fehlgeschlagen');
+                    syncSubToggles(master, enabled, enabled);
+                    updateConsentHint();
+                    showToast(master === 'email'
+                        ? (enabled ? 'E-Mail-Benachrichtigungen aktiviert.' : 'E-Mail-Benachrichtigungen deaktiviert.')
+                        : (enabled ? 'Push-Benachrichtigungen aktiviert.' : 'Push-Benachrichtigungen deaktiviert.'), 'success');
+                } catch (err) {
+                    console.error(err);
+                    input.checked = !enabled;
+                    showToast(err.message || 'Aktion fehlgeschlagen.', 'error');
+                } finally {
+                    setRowSaving(input, false);
+                }
+            });
+        });
+
+        card.querySelectorAll('input[data-notif-category]').forEach(function (input) {
+            input.addEventListener('change', async function () {
+                var channel = input.getAttribute('data-notif-channel');
+                var category = input.getAttribute('data-notif-category');
+                var enabled = input.checked;
+                setRowSaving(input, true);
+                try {
+                    var data = await patch({ channel: channel, category: category, enabled: enabled });
+                    if (!data.success) throw new Error(data.message || 'Speichern fehlgeschlagen');
+                } catch (err) {
+                    console.error(err);
+                    input.checked = !enabled;
+                    showToast(err.message || 'Speichern fehlgeschlagen.', 'error');
+                } finally {
+                    setRowSaving(input, false);
+                }
+            });
+        });
+    })();
+</script>
+@endsection

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -175,26 +175,12 @@
     }
     .bento > .card-identity      { grid-column: span 12; }
     .bento > .card-learning      { grid-column: span 8; }
-    .bento > .card-streak        { grid-column: span 4; }
-    .bento > .card-achievements  { grid-column: span 6; }
-    .bento > .card-exam          { grid-column: span 6; }
-    .bento > .card-account       { grid-column: span 6; }
-    .bento > .card-security      { grid-column: span 6; }
-    .bento > .card-notifications { grid-column: span 6; }
-    .bento > .card-privacy       { grid-column: span 6; }
+    .bento > .card-achievements  { grid-column: span 4; }
     .bento > .card-accessories   { grid-column: span 12; }
-    .bento > .card-meta          { grid-column: span 12; }
-    .bento > .card-danger        { grid-column: span 12; }
 
     @media (max-width: 1024px) {
         .bento > .card-learning,
-        .bento > .card-streak,
-        .bento > .card-achievements,
-        .bento > .card-exam,
-        .bento > .card-account,
-        .bento > .card-security,
-        .bento > .card-notifications,
-        .bento > .card-privacy { grid-column: span 12; }
+        .bento > .card-achievements { grid-column: span 12; }
     }
 
     .card { padding: 1.25rem; border-radius: 0.75rem; }
@@ -234,6 +220,33 @@
     }
     html.light-mode .pf-page-title__h1 { color: var(--thw-blue, #00337F); }
     .pf-page-title__sub { font-size: 0.875rem; color: var(--text-secondary); }
+
+    .pf-settings-gear {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 44px;
+        height: 44px;
+        border-radius: 50%;
+        background: var(--glass-bg, rgba(255,255,255,0.05));
+        border: 1px solid var(--glass-border, rgba(0,51,127,0.15));
+        color: var(--text-secondary);
+        font-size: 1.125rem;
+        text-decoration: none;
+        transition: transform 200ms ease, background 200ms ease, color 200ms ease, border-color 200ms ease;
+        flex-shrink: 0;
+    }
+    .pf-settings-gear:hover {
+        background: rgba(0,51,127,0.1);
+        border-color: rgba(0,51,127,0.4);
+        color: var(--thw-blue);
+        transform: rotate(45deg);
+    }
+    html:not(.light-mode) .pf-settings-gear:hover {
+        background: rgba(91,154,255,0.15);
+        border-color: rgba(91,154,255,0.4);
+        color: #5b9aff;
+    }
 
     /* ─── Form primitives ─── */
     .field { display: block; margin-bottom: 1rem; }
@@ -792,28 +805,17 @@
 
 @section('content')
 @php
-    // Gamification-Daten
     $level = $user->level ?? 1;
     $points = $user->points ?? 0;
     $ringPct = isset($levelProgress) ? max(0, min(100, (int) $levelProgress)) : 0;
     $nextPts = $nextLevelPoints ?? 0;
     $streakDays = $user->streak_days ?? 0;
 
-    // Alle Stats kommen aus der Route
-    $heatPattern = $heatPattern ?? array_fill(0, 28, 0);
     $solvedCount = $solvedTotal ?? 0;
     $wrongCount = $wrongTotal ?? 0;
     $accuracy = $hitRate ?? null;
     $totalQuestions = $totalQuestions ?? 0;
-    $topSections = $topSections ?? [];
-    $sectionsStarted = $sectionsStarted ?? 0;
-    $sectionsTotal = $sectionsTotal ?? 10;
     $streakDaysArr = $streakDaysArr ?? [];
-
-    $daysSince = (int) floor($user->created_at->diffInDays(now()));
-    $lastActive = $user->last_activity_at
-        ? (\Illuminate\Support\Carbon::parse($user->last_activity_at))
-        : ($user->last_login_at ?? null);
 
     $totalOwnedAccessories = count($ownedAccessories['accessories'] ?? [])
         + count($ownedAccessories['top'] ?? [])
@@ -822,46 +824,24 @@
 
 <div class="dash-container">
 
-    {{-- ── Page Title ── --}}
-    <div class="pf-page-title">
-        <div class="pf-page-title__eyebrow">Einstellungen</div>
-        <h1 class="pf-page-title__h1">Profil</h1>
-        <div class="pf-page-title__sub">Verwalte deine persönlichen Daten, Fortschritt und Datenschutz.</div>
+    <div class="pf-page-title" style="display:flex;align-items:flex-start;justify-content:space-between;gap:1rem;">
+        <div>
+            <div class="pf-page-title__eyebrow">Dein Konto</div>
+            <h1 class="pf-page-title__h1">Profil</h1>
+            <div class="pf-page-title__sub">Avatar, Fortschritt und Achievements.</div>
+        </div>
+        <a href="{{ route('einstellungen') }}" class="pf-settings-gear" title="Einstellungen" aria-label="Einstellungen">
+            <i class="bi bi-gear-fill"></i>
+        </a>
     </div>
 
-    {{-- ── Status Messages ── --}}
-    @if (session('status'))
+    @if (session('status') && session('status') === 'avatar-updated')
     <div class="alert-compact glass-success" style="margin-bottom: 1rem;">
         <i class="bi bi-check-circle alert-compact-icon"></i>
         <div class="alert-compact-content">
-            <div class="alert-compact-title">
-                @if(session('status') == 'profile-updated') Profil erfolgreich aktualisiert.
-                @elseif(session('status') == 'password-updated') Passwort erfolgreich geändert.
-                @elseif(session('status') == 'email-change-cancelled') E-Mail-Änderung abgebrochen.
-                @elseif(session('status') == 'extras-enabled-updated') Zusatz-Fragen-Einstellung gespeichert.
-                @elseif(session('status') == 'avatar-updated') Avatar aktualisiert.
-                @else {{ session('status') }}
-                @endif
-            </div>
+            <div class="alert-compact-title">Avatar aktualisiert.</div>
         </div>
         <button style="background:none;border:none;cursor:pointer;font-size:1.25rem;color:var(--text-secondary);" onclick="this.parentElement.remove()">&times;</button>
-    </div>
-    @endif
-
-    @if ($user->pending_email)
-    <div class="alert-compact glass-warning" style="margin-bottom: 1rem;">
-        <i class="bi bi-clock-history alert-compact-icon"></i>
-        <div class="alert-compact-content">
-            <div class="alert-compact-title">E-Mail-Änderung ausstehend</div>
-            <div class="alert-compact-desc">
-                Bestätigungscode gesendet an <strong>{{ $user->pending_email }}</strong>.
-                <a href="{{ route('verification.notice') }}" style="color:var(--gold);text-decoration:underline;">Jetzt bestätigen</a>
-                <form method="POST" action="{{ route('profile.cancel-email-change') }}" style="display:inline;">
-                    @csrf
-                    <button type="submit" style="background:none;border:none;color:var(--text-secondary);text-decoration:underline;cursor:pointer;padding:0;font-size:inherit;">Abbrechen</button>
-                </form>
-            </div>
-        </div>
     </div>
     @endif
 
@@ -959,61 +939,6 @@
                     </div>
                 </div>
 
-                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.5rem;padding-top:0.25rem;">
-                    <span class="section-label" style="font-size:0.6875rem;">Lernabschnitte · Top 3</span>
-                    <span style="font-size:0.75rem;color:var(--text-muted);">{{ $sectionsStarted }} / {{ $sectionsTotal }} begonnen</span>
-                </div>
-
-                <div class="section-list">
-                    @forelse($topSections as $idx => $sec)
-                        @php
-                            $rank = $idx + 1;
-                            $isEmpty = $sec['solved'] === 0;
-                        @endphp
-                        <a href="{{ route('practice.menu') }}" class="section-row {{ $isEmpty ? 'section-row--empty' : '' }}">
-                            <div class="section-row__rank">{{ $rank }}</div>
-                            <div class="section-row__body">
-                                <div class="section-row__name">{{ $sec['name'] }}</div>
-                                <div class="section-row__bar"><div class="section-row__fill" style="width: {{ $sec['percent'] }}%;"></div></div>
-                            </div>
-                            <div class="section-row__pct">{{ $isEmpty ? '—' : $sec['percent'].'%' }}</div>
-                            <i class="bi bi-chevron-right section-row__chev"></i>
-                        </a>
-                    @empty
-                        <div style="padding:0.75rem;text-align:center;color:var(--text-muted);font-size:0.8125rem;">Noch keine Lernabschnitte begonnen.</div>
-                    @endforelse
-                </div>
-            </div>
-        </div>
-
-        {{-- ══════════════════════════════════════════
-             STREAK HEATMAP (span 4)
-        ══════════════════════════════════════════ --}}
-        <div class="glass card-streak card">
-            <div class="card-head">
-                <span class="section-label">Streak · Letzte 28 Tage</span>
-            </div>
-            <div>
-                <div class="streak-hero">
-                    <div class="streak-num">{{ $streakDays }}</div>
-                    <div class="streak-label">Aktuelle Serie</div>
-                </div>
-                <div class="heat-grid">
-                    @foreach($heatPattern as $v)
-                        <div class="heat-cell" data-v="{{ $v }}"></div>
-                    @endforeach
-                </div>
-                <div class="heat-legend">
-                    <span>Weniger</span>
-                    <div class="heat-legend__scale">
-                        <div class="heat-legend__swatch heat-cell" data-v="0"></div>
-                        <div class="heat-legend__swatch heat-cell" data-v="1"></div>
-                        <div class="heat-legend__swatch heat-cell" data-v="2"></div>
-                        <div class="heat-legend__swatch heat-cell" data-v="3"></div>
-                        <div class="heat-legend__swatch heat-cell" data-v="4"></div>
-                    </div>
-                    <span>Mehr</span>
-                </div>
             </div>
         </div>
 
@@ -1045,370 +970,11 @@
             </div>
         </div>
 
-        {{-- ══════════════════════════════════════════
-             EXAM / ZUSATZ-FRAGEN (span 6) — REAL
-        ══════════════════════════════════════════ --}}
-        <div class="glass card-exam card">
-            <div class="card-head">
-                <span class="section-label">Prüfung & Zusatz-Fragen</span>
-            </div>
+        {{-- Account-Verwaltung (entfernt - siehe /einstellungen) --}}
 
-            <form method="POST" action="{{ route('profile.update') }}" id="exam-date-form">
-                @csrf
-                @method('PATCH')
-                {{-- Nur exam_date wird hier aktualisiert; name/email werden aus dem Haupt-Formular gespeichert --}}
-                <input type="hidden" name="name" value="{{ $user->name }}">
-                <input type="hidden" name="email" value="{{ $user->email }}">
-                <input type="hidden" name="email_consent" value="{{ $user->email_consent ? 1 : 0 }}">
-                <input type="hidden" name="leaderboard_consent" value="{{ $user->leaderboard_consent ? 1 : 0 }}">
+        {{-- Sicherheit (entfernt - siehe /einstellungen) --}}
 
-                <div class="field">
-                    <label class="field__label" for="exam-date">Prüfungsdatum (optional)</label>
-                    <div class="field__row">
-                        <input class="input @error('exam_date') input--error @enderror" type="date" id="exam-date" name="exam_date"
-                               value="{{ old('exam_date', $user->exam_date?->format('Y-m-d')) }}"
-                               min="{{ date('Y-m-d', strtotime('+1 day')) }}">
-                        <button class="btn-pf-ghost" type="button" onclick="document.getElementById('exam-date').value=''">Zurücksetzen</button>
-                    </div>
-                    @error('exam_date')
-                        <div class="field__error">{{ $message }}</div>
-                    @else
-                        <div class="field__help">Für eine personalisierte Lernempfehlung auf dem Dashboard.</div>
-                    @enderror
-                </div>
-            </form>
-
-            <form method="POST" action="{{ route('profile.extras-enabled') }}">
-                @csrf
-                <input type="hidden" name="extras_enabled" value="0">
-                <div class="toggle-row">
-                    <div class="toggle-row__body">
-                        <div class="toggle-row__title">Zusatz-Fragen aktivieren</div>
-                        <div class="toggle-row__desc">Zusätzliche außerhalb-der-Prüfung Übungsfragen. Erscheinen im Übungsmodus und beeinflussen nicht deine Prüfungsauswertung.</div>
-                    </div>
-                    <label class="switch">
-                        <input type="checkbox" name="extras_enabled" value="1" onchange="this.form.submit()" {{ $user->extras_enabled ? 'checked' : '' }}>
-                        <span class="switch__slider"></span>
-                    </label>
-                </div>
-            </form>
-
-            <div class="card-foot">
-                <span class="card-foot__note">Änderungen am Prüfungsdatum nach dem Speichern aktiv.</span>
-                <button class="btn-pf-primary" type="button" onclick="document.getElementById('exam-date-form').submit()">Speichern</button>
-            </div>
-        </div>
-
-        {{-- ══════════════════════════════════════════
-             PERSÖNLICHE DATEN (span 6) — REAL
-        ══════════════════════════════════════════ --}}
-        <div class="glass card-account card">
-            <div class="card-head">
-                <span class="section-label">Persönliche Daten</span>
-            </div>
-
-            <form method="POST" action="{{ route('profile.update') }}" id="profile-main-form">
-                @csrf
-                @method('PATCH')
-
-                <div class="field">
-                    <label class="field__label" for="name">Name</label>
-                    <input class="input @error('name') input--error @enderror" type="text" id="name" name="name"
-                           value="{{ old('name', $user->name) }}" required maxlength="255">
-                    @error('name')
-                        <div class="field__error">{{ $message }}</div>
-                    @else
-                        <div class="field__help">Dieser Name erscheint im Leaderboard.</div>
-                    @enderror
-                </div>
-
-                <div class="field">
-                    <label class="field__label" for="email">E-Mail-Adresse</label>
-                    <input class="input @error('email') input--error @enderror" type="email" id="email" name="email"
-                           value="{{ old('email', $user->email) }}" required>
-                    @error('email')
-                        <div class="field__error">{{ $message }}</div>
-                    @else
-                        <div class="field__help">Änderungen erfordern eine Bestätigung per E-Mail.</div>
-                    @enderror
-                </div>
-
-                <div class="field">
-                    <label class="field__label">Ortsverband</label>
-                    @if(($ortsverbande ?? collect())->isNotEmpty())
-                        <div style="display:flex;flex-direction:column;gap:0.5rem;">
-                            @foreach($ortsverbande as $ov)
-                                <a href="{{ route('ortsverband.show', $ov) }}" style="display:flex;align-items:center;gap:0.75rem;padding:0.625rem 0.875rem;border:1px solid rgba(0,51,127,0.15);border-radius:10px;background:rgba(0,51,127,0.04);text-decoration:none;color:var(--text-primary);transition:background 0.15s;">
-                                    <i class="bi bi-building" style="color:var(--thw-blue);font-size:1.125rem;"></i>
-                                    <div style="flex:1;">
-                                        <div style="font-weight:600;font-size:0.9375rem;">{{ $ov->name }}</div>
-                                        @if($ov->pivot->role ?? null)
-                                            <div style="font-size:0.75rem;color:var(--text-muted);">{{ ucfirst($ov->pivot->role) }}</div>
-                                        @endif
-                                    </div>
-                                    <i class="bi bi-chevron-right" style="color:var(--text-muted);font-size:0.875rem;"></i>
-                                </a>
-                            @endforeach
-                        </div>
-                        <div class="field__help">Mitgliedschaften verwalten auf der Ortsverband-Seite.</div>
-                    @else
-                        <div style="padding:1rem;border:1px dashed rgba(0,51,127,0.2);border-radius:10px;background:rgba(0,51,127,0.03);text-align:center;">
-                            <div style="font-size:0.875rem;color:var(--text-secondary);margin-bottom:0.75rem;">
-                                Du bist noch keinem Ortsverband beigetreten.
-                            </div>
-                            <a href="{{ route('ortsverband.index') }}" class="btn-pf-primary" style="display:inline-flex;align-items:center;gap:0.5rem;">
-                                <i class="bi bi-plus-circle"></i> Ortsverband beitreten
-                            </a>
-                        </div>
-                        <div class="field__help">Tritt deinem Ortsverband bei, um Fortschritt und Ranking zu teilen.</div>
-                    @endif
-                </div>
-
-                <input type="hidden" name="email_consent" value="{{ $user->email_consent ? 1 : 0 }}">
-                <input type="hidden" name="leaderboard_consent" value="{{ $user->leaderboard_consent ? 1 : 0 }}">
-                <input type="hidden" name="exam_date" value="{{ $user->exam_date?->format('Y-m-d') }}">
-
-                <div class="card-foot">
-                    <span class="card-foot__note">Änderungen werden nach dem Speichern aktiv.</span>
-                    <button class="btn-pf-primary" type="submit">Profil speichern</button>
-                </div>
-            </form>
-        </div>
-
-        {{-- ══════════════════════════════════════════
-             SECURITY (span 6) — Passwort REAL, 2FA [GREYED]
-        ══════════════════════════════════════════ --}}
-        <div class="glass card-security card">
-            <div class="card-head">
-                <span class="section-label">Sicherheit</span>
-            </div>
-
-            <form method="POST" action="{{ route('profile.password.update') }}">
-                @csrf
-                @method('PATCH')
-
-                <div class="field">
-                    <label class="field__label" for="current_password">Aktuelles Passwort</label>
-                    <input class="input @error('current_password') input--error @enderror" type="password"
-                           id="current_password" name="current_password" placeholder="Aktuelles Passwort">
-                    @error('current_password')<div class="field__error">{{ $message }}</div>@enderror
-                </div>
-
-                <div class="field">
-                    <label class="field__label" for="password">Neues Passwort</label>
-                    <input class="input @error('password') input--error @enderror" type="password"
-                           id="password" name="password" placeholder="Mindestens 8 Zeichen"
-                           oninput="checkPasswordMatch()">
-                    @error('password')<div class="field__error">{{ $message }}</div>@enderror
-                </div>
-
-                <div class="field">
-                    <label class="field__label" for="password_confirmation">Passwort bestätigen</label>
-                    <input class="input" type="password" id="password_confirmation" name="password_confirmation"
-                           placeholder="Passwort wiederholen" oninput="checkPasswordMatch()">
-                    <div id="password-match-message" class="pf-pw-msg"></div>
-                </div>
-
-                <div class="toggle-row is-locked">
-                    <div class="toggle-row__body card-body-locked">
-                        <div class="toggle-row__title">
-                            Zwei-Faktor-Authentifizierung (2FA)
-                            <span class="locked-badge"><i class="bi bi-lock"></i> Bald</span>
-                        </div>
-                        <div class="toggle-row__desc">Zusätzlicher Schutz per TOTP-App (z. B. Aegis, Authy). Empfohlen für Admin-Accounts.</div>
-                    </div>
-                    <label class="switch">
-                        <input type="checkbox" disabled>
-                        <span class="switch__slider"></span>
-                    </label>
-                </div>
-
-                <div class="card-foot">
-                    <span class="card-foot__note">Nach Passwortänderung bleibst du angemeldet.</span>
-                    <button class="btn-pf-primary" type="submit">Passwort ändern</button>
-                </div>
-            </form>
-        </div>
-
-        {{-- ══════════════════════════════════════════
-             NOTIFICATIONS (span 6) — Master + Per-Kategorie (E-Mail + Push)
-        ══════════════════════════════════════════ --}}
-        @php
-            $notifCategories = [
-                'daily_reminder' => [
-                    'title' => 'Tägliche Lernerinnerung',
-                    'desc'  => 'Eine kurze Erinnerung, wenn du deinen Streak zu verlieren drohst.',
-                ],
-                'spaced_repetition' => [
-                    'title' => 'Spaced-Repetition-Reviews',
-                    'desc'  => 'Benachrichtigung, sobald Fragen zur Wiederholung fällig sind.',
-                ],
-                'league_updates' => [
-                    'title' => 'Liga- & Achievement-Updates',
-                    'desc'  => 'Wenn du aufsteigst, fällst oder ein neues Achievement freischaltest.',
-                ],
-            ];
-        @endphp
-        <div class="glass card-notifications card" id="notif-card">
-            <div class="card-head">
-                <span class="section-label">Benachrichtigungen</span>
-                <span class="card-head__hint" id="notif-consent-hint">
-                    @if($user->email_consent_at && $user->push_consent_at)
-                        E-Mail seit {{ $user->email_consent_at->format('d.m.Y') }} · Push seit {{ $user->push_consent_at->format('d.m.Y') }}
-                    @elseif($user->email_consent_at)
-                        E-Mail seit {{ $user->email_consent_at->format('d.m.Y') }}
-                    @elseif($user->push_consent_at)
-                        Push seit {{ $user->push_consent_at->format('d.m.Y') }}
-                    @else
-                        Noch nicht aktiviert
-                    @endif
-                </span>
-            </div>
-
-            {{-- Master-Toggles: E-Mail + Push --}}
-            <div class="notif-master">
-                <div class="toggle-row notif-master-row">
-                    <div class="toggle-row__body">
-                        <div class="toggle-row__title">
-                            <i class="bi bi-envelope-fill" style="color: var(--thw-blue, #00337F);"></i>
-                            E-Mail-Benachrichtigungen
-                        </div>
-                        <div class="toggle-row__desc">Erhalte E-Mails zu Lernfortschritt, neuen Features und Systeminformationen.</div>
-                    </div>
-                    <label class="switch">
-                        <input type="checkbox"
-                               data-notif-master="email"
-                               {{ $user->email_consent ? 'checked' : '' }}>
-                        <span class="switch__slider"></span>
-                    </label>
-                </div>
-
-                <div class="toggle-row notif-master-row">
-                    <div class="toggle-row__body">
-                        <div class="toggle-row__title">
-                            <i class="bi bi-bell-fill" style="color: var(--thw-blue, #00337F);"></i>
-                            Push-Benachrichtigungen
-                        </div>
-                        <div class="toggle-row__desc">Browser- und App-Push für wichtige Updates direkt auf dein Gerät.</div>
-                    </div>
-                    <label class="switch">
-                        <input type="checkbox"
-                               data-notif-master="push"
-                               {{ $user->push_consent ? 'checked' : '' }}>
-                        <span class="switch__slider"></span>
-                    </label>
-                </div>
-            </div>
-
-            {{-- Per-Kategorie: E-Mail + Push --}}
-            <div class="notif-categories">
-                <div class="notif-categories__header">
-                    <span class="notif-categories__label">Einzelne Benachrichtigungen</span>
-                    <div class="notif-categories__legend">
-                        <span title="E-Mail"><i class="bi bi-envelope"></i></span>
-                        <span title="Push"><i class="bi bi-bell"></i></span>
-                    </div>
-                </div>
-
-                @foreach($notifCategories as $key => $cat)
-                    <div class="toggle-row notif-cat-row">
-                        <div class="toggle-row__body">
-                            <div class="toggle-row__title">{{ $cat['title'] }}</div>
-                            <div class="toggle-row__desc">{{ $cat['desc'] }}</div>
-                        </div>
-                        <div class="notif-cat-switches">
-                            <label class="switch switch--mini" title="E-Mail">
-                                <input type="checkbox"
-                                       data-notif-channel="email"
-                                       data-notif-category="{{ $key }}"
-                                       {{ $user->{"notify_{$key}_email"} ? 'checked' : '' }}
-                                       {{ $user->email_consent ? '' : 'disabled' }}>
-                                <span class="switch__slider"></span>
-                            </label>
-                            <label class="switch switch--mini" title="Push">
-                                <input type="checkbox"
-                                       data-notif-channel="push"
-                                       data-notif-category="{{ $key }}"
-                                       {{ $user->{"notify_{$key}_push"} ? 'checked' : '' }}
-                                       {{ $user->push_consent ? '' : 'disabled' }}>
-                                <span class="switch__slider"></span>
-                            </label>
-                        </div>
-                    </div>
-                @endforeach
-            </div>
-        </div>
-
-        {{-- ══════════════════════════════════════════
-             PRIVACY (span 6) — Leaderboard REAL, Rest teilweise [GREYED]
-        ══════════════════════════════════════════ --}}
-        <div class="glass card-privacy card">
-            <div class="card-head">
-                <span class="section-label">Privatsphäre & Datenschutz</span>
-                <a href="/datenschutz" class="card-head__hint" style="color: var(--thw-blue, #00337F); text-decoration: none; font-weight: 600;">Datenschutzerklärung →</a>
-            </div>
-
-            <form method="POST" action="{{ route('profile.update') }}" id="privacy-form">
-                @csrf
-                @method('PATCH')
-                <input type="hidden" name="name" value="{{ $user->name }}">
-                <input type="hidden" name="email" value="{{ $user->email }}">
-                <input type="hidden" name="email_consent" value="{{ $user->email_consent ? 1 : 0 }}">
-                <input type="hidden" name="exam_date" value="{{ $user->exam_date?->format('Y-m-d') }}">
-                <input type="hidden" name="leaderboard_consent" value="0">
-
-                <div class="toggle-row">
-                    <div class="toggle-row__body">
-                        <div class="toggle-row__title">Leaderboard-Teilnahme</div>
-                        <div class="toggle-row__desc">Dein Name erscheint im öffentlichen Leaderboard. Deaktivieren macht dein Konto anonym.</div>
-                    </div>
-                    <label class="switch">
-                        <input type="checkbox" name="leaderboard_consent" value="1" onchange="this.form.submit()" {{ $user->leaderboard_consent ? 'checked' : '' }}>
-                        <span class="switch__slider"></span>
-                    </label>
-                </div>
-            </form>
-
-            <div class="toggle-row is-locked">
-                <div class="toggle-row__body card-body-locked">
-                    <div class="toggle-row__title">
-                        OV-Ranking sichtbar
-                        <span class="locked-badge"><i class="bi bi-lock"></i> Bald</span>
-                    </div>
-                    <div class="toggle-row__desc">Mitglieder deines Ortsverbandes sehen deinen Fortschritt im OV-Dashboard.</div>
-                </div>
-                <label class="switch"><input type="checkbox" disabled><span class="switch__slider"></span></label>
-            </div>
-
-            <div class="info-row">
-                <div class="info-row__icon"><i class="bi bi-info-circle-fill"></i></div>
-                <div class="info-row__body">
-                    <div class="info-row__title">Aggregierte Nutzungsstatistik</div>
-                    <div class="info-row__desc">
-                        Zur Produktverbesserung erheben wir ausschließlich <strong>aggregierte, anonyme Statistiken</strong>. Keine personenbezogenen Daten, keine Weitergabe an Dritte, kein externes Tracking.
-                    </div>
-                </div>
-            </div>
-
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid rgba(0,51,127,0.06);" class="is-locked">
-                <div class="card-body-locked">
-                    <a class="link-row" href="#" onclick="event.preventDefault()">
-                        <div>
-                            <div class="link-row__title"><i class="bi bi-download" style="margin-right: 0.4rem;"></i> Datenexport anfordern (Art. 20 DSGVO) <span class="locked-badge" style="margin-left:0.5rem;"><i class="bi bi-lock"></i> Bald</span></div>
-                            <div class="link-row__sub">JSON-Export deiner Lerndaten, Antworten und Profilfelder — per E-Mail binnen 72 Std.</div>
-                        </div>
-                        <i class="bi bi-chevron-right"></i>
-                    </a>
-                    <a class="link-row" href="#" onclick="event.preventDefault()">
-                        <div>
-                            <div class="link-row__title"><i class="bi bi-shield-lock" style="margin-right: 0.4rem;"></i> Aktive Sessions & Geräte <span class="locked-badge" style="margin-left:0.5rem;"><i class="bi bi-lock"></i> Bald</span></div>
-                            <div class="link-row__sub">Aktive Geräte und letzte Anmeldungen verwalten.</div>
-                        </div>
-                        <i class="bi bi-chevron-right"></i>
-                    </a>
-                </div>
-            </div>
-        </div>
+        {{-- Benachrichtigungen, Privatsphäre (entfernt - siehe /einstellungen) --}}
 
         {{-- ══════════════════════════════════════════
              AVATAR-ACCESSOIRES (span 12) — REAL
@@ -1483,94 +1049,10 @@
             @endif
         </div>
 
-        {{-- ══════════════════════════════════════════
-             KONTO-META (span 12) — REAL
-        ══════════════════════════════════════════ --}}
-        <div class="glass card-meta card">
-            <div class="card-head">
-                <span class="section-label">Konto-Details</span>
-            </div>
-            <div class="meta-grid">
-                <div class="meta-item">
-                    <div class="meta-item__label">Beitrittsdatum</div>
-                    <div class="meta-item__value">{{ $user->created_at->format('d.m.Y') }}</div>
-                    <div class="meta-item__sub">vor {{ $daysSince }} {{ $daysSince === 1 ? 'Tag' : 'Tagen' }}</div>
-                </div>
-                <div class="meta-item">
-                    <div class="meta-item__label">Konto-Status</div>
-                    @if($user->pending_email)
-                        <div class="meta-item__value" style="color: #f59e0b;">E-Mail-Änderung</div>
-                        <div class="meta-item__sub">Bestätigung an {{ $user->pending_email }}</div>
-                    @elseif($user->hasVerifiedEmail())
-                        <div class="meta-item__value" style="color: #22c55e;">Bestätigt</div>
-                        <div class="meta-item__sub">E-Mail verifiziert</div>
-                    @else
-                        <div class="meta-item__value" style="color: #f59e0b;">Ausstehend</div>
-                        <div class="meta-item__sub">E-Mail nicht verifiziert</div>
-                    @endif
-                </div>
-                <div class="meta-item">
-                    <div class="meta-item__label">Zuletzt aktiv</div>
-                    <div class="meta-item__value">{{ $lastActive ? $lastActive->diffForHumans() : 'Gerade eben' }}</div>
-                    <div class="meta-item__sub">{{ $lastActive ? $lastActive->format('d.m.Y H:i') : 'Erste Anmeldung' }}</div>
-                </div>
-            </div>
-        </div>
-
-        {{-- ══════════════════════════════════════════
-             DANGER ZONE (span 12) — REAL
-        ══════════════════════════════════════════ --}}
-        <div class="card-danger">
-            <div class="danger-card">
-                <div class="danger-head">
-                    <div class="danger-icon"><i class="bi bi-exclamation-triangle-fill"></i></div>
-                    <div>
-                        <span class="section-label">Danger Zone</span>
-                        <div class="danger-title">Account permanent löschen</div>
-                    </div>
-                </div>
-                <div class="danger-desc">
-                    Diese Aktion kann <strong>nicht rückgängig</strong> gemacht werden. Alle deine Daten — Antworten, Fortschritt, Achievements — werden unwiderruflich gelöscht (Art. 17 DSGVO · Recht auf Löschung).
-                </div>
-                <form method="POST" action="{{ route('profile.destroy') }}"
-                      onsubmit="return confirm('Bist du dir absolut sicher? Alle deine Daten werden permanent gelöscht.')">
-                    @csrf
-                    @method('DELETE')
-                    <div class="field">
-                        <label class="field__label" for="password_delete">Passwort zur Bestätigung</label>
-                        <input class="input @error('password', 'userDeletion') input--error @enderror" type="password"
-                               id="password_delete" name="password" placeholder="Passwort eingeben" style="max-width: 320px;">
-                        @error('password', 'userDeletion')<div class="field__error">{{ $message }}</div>@enderror
-                    </div>
-                    <div style="display: flex; gap: 0.75rem; align-items: center; margin-top: 1rem; flex-wrap: wrap;">
-                        <button class="btn-danger-inline" type="submit"><i class="bi bi-trash3-fill"></i> Account permanent löschen</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-
     </div>{{-- /.bento --}}
 </div>{{-- /.dash-container --}}
 
 <script>
-    function checkPasswordMatch() {
-        var pw = document.getElementById('password').value;
-        var confirm = document.getElementById('password_confirmation').value;
-        var msg = document.getElementById('password-match-message');
-        if (pw && confirm) {
-            var match = pw === confirm;
-            document.getElementById('password').classList.toggle('input--error', !match);
-            document.getElementById('password_confirmation').classList.toggle('input--error', !match);
-            msg.style.display = 'flex';
-            msg.style.color = match ? '#22c55e' : '#ef4444';
-            msg.innerHTML = '<i class="bi bi-' + (match ? 'check' : 'x') + '-circle"></i> Passwörter stimmen ' + (match ? 'überein' : 'nicht überein');
-        } else {
-            document.getElementById('password').classList.remove('input--error');
-            document.getElementById('password_confirmation').classList.remove('input--error');
-            msg.style.display = 'none';
-        }
-    }
-
     function accessoryManager() {
         return {
             activeItems: @json($user->active_accessories ?? (object)[]),
@@ -1650,191 +1132,6 @@
             }
         };
     }
-
-    // ─── Notification preferences (Master + Per-Channel/Per-Category) ───
-    (function () {
-        var card = document.getElementById('notif-card');
-        if (!card) return;
-
-        var csrf = document.querySelector('meta[name="csrf-token"]').content;
-        var endpoint = '{{ route("profile.notification-preferences") }}';
-        var vapidPublicKey = @json(config('services.webpush.public_key'));
-
-        function setRowSaving(input, saving) {
-            var row = input.closest('.toggle-row');
-            if (row) row.classList.toggle('is-saving', saving);
-        }
-
-        function showToast(msg, type) {
-            var toast = document.createElement('div');
-            var bg = type === 'error' ? '#ef4444' : '#22c55e';
-            toast.style.cssText = 'position:fixed;bottom:1rem;right:1rem;background:' + bg + ';color:#fff;padding:0.75rem 1rem;border-radius:0.5rem;box-shadow:0 4px 12px rgba(0,0,0,0.2);z-index:9999;font-size:0.875rem;max-width:320px;';
-            toast.textContent = msg;
-            document.body.appendChild(toast);
-            setTimeout(function () { toast.remove(); }, 3500);
-        }
-
-        async function patch(payload) {
-            var res = await fetch(endpoint, {
-                method: 'PATCH',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': csrf,
-                    'Accept': 'application/json',
-                },
-                body: JSON.stringify(payload),
-                cache: 'no-store',
-            });
-            if (!res.ok) throw new Error('HTTP ' + res.status);
-            return res.json();
-        }
-
-        function syncSubToggles(channel, masterEnabled, forceCheckAll) {
-            card.querySelectorAll('input[data-notif-channel="' + channel + '"]').forEach(function (input) {
-                input.disabled = !masterEnabled;
-                if (forceCheckAll && masterEnabled) {
-                    input.checked = true;
-                }
-            });
-        }
-
-        function updateConsentHint() {
-            var hint = document.getElementById('notif-consent-hint');
-            if (!hint) return;
-            var emailMaster = card.querySelector('input[data-notif-master="email"]');
-            var pushMaster = card.querySelector('input[data-notif-master="push"]');
-            var parts = [];
-            if (emailMaster && emailMaster.checked) parts.push('E-Mail aktiv');
-            if (pushMaster && pushMaster.checked) parts.push('Push aktiv');
-            hint.textContent = parts.length ? parts.join(' · ') : 'Noch nicht aktiviert';
-        }
-
-        function urlBase64ToUint8Array(base64String) {
-            var padding = '='.repeat((4 - base64String.length % 4) % 4);
-            var base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
-            var raw = atob(base64);
-            var arr = new Uint8Array(raw.length);
-            for (var i = 0; i < raw.length; ++i) arr[i] = raw.charCodeAt(i);
-            return arr;
-        }
-
-        async function enableBrowserPush() {
-            if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
-                throw new Error('Push wird in diesem Browser nicht unterstützt.');
-            }
-            if (!vapidPublicKey) {
-                throw new Error('Push-Konfiguration fehlt (VAPID).');
-            }
-
-            var permission = await Notification.requestPermission();
-            if (permission !== 'granted') {
-                throw new Error('Du hast Push-Benachrichtigungen im Browser nicht erlaubt.');
-            }
-
-            var registration = await navigator.serviceWorker.register('/sw.js');
-            await navigator.serviceWorker.ready;
-
-            var subscription = await registration.pushManager.getSubscription();
-            if (!subscription) {
-                subscription = await registration.pushManager.subscribe({
-                    userVisibleOnly: true,
-                    applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
-                });
-            }
-
-            var sub = subscription.toJSON();
-            await fetch('{{ route("push.subscribe") }}', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': csrf,
-                },
-                body: JSON.stringify({
-                    endpoint: sub.endpoint,
-                    keys: sub.keys,
-                    content_encoding: 'aes128gcm',
-                }),
-            });
-        }
-
-        async function disableBrowserPush() {
-            if (!('serviceWorker' in navigator)) return;
-            var registration = await navigator.serviceWorker.getRegistration();
-            if (!registration) return;
-            var subscription = await registration.pushManager.getSubscription();
-            if (!subscription) return;
-
-            var endpointUrl = subscription.endpoint;
-            try { await subscription.unsubscribe(); } catch (e) { console.warn(e); }
-
-            await fetch('{{ route("push.unsubscribe") }}', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': csrf,
-                },
-                body: JSON.stringify({ endpoint: endpointUrl }),
-            });
-        }
-
-        // ─── Master-Toggles (E-Mail / Push) ───
-        card.querySelectorAll('input[data-notif-master]').forEach(function (input) {
-            input.addEventListener('change', async function () {
-                var master = input.getAttribute('data-notif-master');
-                var enabled = input.checked;
-                setRowSaving(input, true);
-
-                try {
-                    if (master === 'push') {
-                        if (enabled) {
-                            await enableBrowserPush();
-                        } else {
-                            await disableBrowserPush();
-                        }
-                    }
-
-                    var data = await patch({ master: master, enabled: enabled });
-                    if (!data.success) throw new Error(data.message || 'Speichern fehlgeschlagen');
-
-                    syncSubToggles(master, enabled, enabled);
-                    updateConsentHint();
-                    showToast(
-                        master === 'email'
-                            ? (enabled ? 'E-Mail-Benachrichtigungen aktiviert.' : 'E-Mail-Benachrichtigungen deaktiviert.')
-                            : (enabled ? 'Push-Benachrichtigungen aktiviert.' : 'Push-Benachrichtigungen deaktiviert.'),
-                        'success'
-                    );
-                } catch (err) {
-                    console.error(err);
-                    input.checked = !enabled;
-                    showToast(err.message || 'Aktion fehlgeschlagen.', 'error');
-                } finally {
-                    setRowSaving(input, false);
-                }
-            });
-        });
-
-        // ─── Sub-Toggles (Per-Kategorie x Kanal) ───
-        card.querySelectorAll('input[data-notif-category]').forEach(function (input) {
-            input.addEventListener('change', async function () {
-                var channel = input.getAttribute('data-notif-channel');
-                var category = input.getAttribute('data-notif-category');
-                var enabled = input.checked;
-                setRowSaving(input, true);
-
-                try {
-                    var data = await patch({ channel: channel, category: category, enabled: enabled });
-                    if (!data.success) throw new Error(data.message || 'Speichern fehlgeschlagen');
-                } catch (err) {
-                    console.error(err);
-                    input.checked = !enabled;
-                    showToast(err.message || 'Speichern fehlgeschlagen.', 'error');
-                } finally {
-                    setRowSaving(input, false);
-                }
-            });
-        });
-    })();
 
     // Avatar regeneration
     var regenBtn = document.getElementById('pf-regen-btn');

--- a/resources/views/statistics.blade.php
+++ b/resources/views/statistics.blade.php
@@ -1,6 +1,73 @@
 @extends('layouts.app')
 @section('title', 'Statistiken')
 
+@push('styles')
+<style>
+    .stat-top-list { display: flex; flex-direction: column; }
+    .stat-top-row {
+        display: grid;
+        grid-template-columns: 28px 1fr auto 14px;
+        gap: 0.75rem;
+        align-items: center;
+        padding: 0.625rem 0;
+        border-top: 1px solid rgba(0,51,127,0.08);
+        text-decoration: none;
+        color: inherit;
+        transition: background 0.15s;
+    }
+    .stat-top-row:first-child { border-top: 0; }
+    .stat-top-row:hover { background: rgba(0,51,127,0.03); }
+    .stat-top-row__rank {
+        display: flex; align-items: center; justify-content: center;
+        width: 28px; height: 28px; border-radius: 7px;
+        background: var(--thw-blue); color: #fff;
+        font-size: 0.8125rem; font-weight: 700;
+    }
+    .stat-top-row__body { min-width: 0; }
+    .stat-top-row__name {
+        font-size: 0.875rem; color: var(--text-primary); font-weight: 500;
+        white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+        margin-bottom: 0.375rem;
+    }
+    .stat-top-row__bar { height: 3px; border-radius: 2px; background: rgba(0,51,127,0.08); overflow: hidden; }
+    .stat-top-row__fill { height: 100%; background: var(--thw-blue); border-radius: 2px; transition: width 0.4s ease; }
+    .stat-top-row__pct { font-size: 0.8125rem; font-weight: 600; color: var(--thw-blue); min-width: 36px; text-align: right; }
+    .stat-top-row__chev { color: var(--text-muted); font-size: 0.75rem; }
+
+    .stat-streak-hero { text-align: center; padding: 0.5rem 0 1rem; }
+    .stat-streak-num {
+        font-family: 'Barlow Condensed', 'Figtree', sans-serif;
+        font-weight: 800; font-size: 2.5rem; line-height: 1;
+        color: #fbbf24; letter-spacing: -0.03em;
+    }
+    html.light-mode .stat-streak-num { color: #f59e0b; }
+    .stat-streak-label {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.6875rem; font-weight: 600;
+        text-transform: uppercase; letter-spacing: 0.1em;
+        color: var(--text-muted); margin-top: 0.25rem;
+    }
+    .stat-heat-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 3px; }
+    .stat-heat-cell { aspect-ratio: 1; border-radius: 3px; background: rgba(255,255,255,0.06); }
+    .stat-heat-cell[data-v="1"] { background: rgba(91,154,255,0.25); }
+    .stat-heat-cell[data-v="2"] { background: rgba(91,154,255,0.5); }
+    .stat-heat-cell[data-v="3"] { background: rgba(91,154,255,0.75); }
+    .stat-heat-cell[data-v="4"] { background: #00337F; }
+    html.light-mode .stat-heat-cell[data-v="0"] { background: rgba(0,51,127,0.06); }
+    html.light-mode .stat-heat-cell[data-v="1"] { background: rgba(0,51,127,0.22); }
+    html.light-mode .stat-heat-cell[data-v="2"] { background: rgba(0,51,127,0.45); }
+    html.light-mode .stat-heat-cell[data-v="3"] { background: rgba(0,51,127,0.7); }
+    html.light-mode .stat-heat-cell[data-v="4"] { background: #00337F; }
+    .stat-heat-legend {
+        display: flex; align-items: center; justify-content: space-between;
+        margin-top: 0.625rem; font-size: 0.6875rem; color: var(--text-muted);
+        font-family: 'IBM Plex Mono', monospace;
+    }
+    .stat-heat-legend__scale { display: flex; gap: 3px; align-items: center; }
+    .stat-heat-legend__swatch { width: 10px; height: 10px; border-radius: 2px; }
+</style>
+@endpush
+
 @section('content')
 <div class="dash-container">
 
@@ -31,6 +98,29 @@
     <div class="dash-grid">
         {{-- Main: Section Analysis --}}
         <div class="space-y-4">
+            {{-- Top-3 Lernabschnitte --}}
+            <div class="glass p-4" style="border-radius: 0.75rem;">
+                <div class="text-xs uppercase tracking-wider mb-3" style="color: var(--text-muted);">
+                    Top 3 Lernabschnitte
+                </div>
+                <div class="stat-top-list">
+                    @forelse($topSections as $idx => $sec)
+                        @php $rank = $idx + 1; $isEmpty = $sec['mastered'] === 0; @endphp
+                        <a href="{{ route('practice.section', $sec['section']) }}" class="stat-top-row">
+                            <div class="stat-top-row__rank">{{ $rank }}</div>
+                            <div class="stat-top-row__body">
+                                <div class="stat-top-row__name">{{ $sec['name'] }}</div>
+                                <div class="stat-top-row__bar"><div class="stat-top-row__fill" style="width: {{ $sec['percent'] }}%;"></div></div>
+                            </div>
+                            <div class="stat-top-row__pct">{{ $isEmpty ? '—' : $sec['percent'].'%' }}</div>
+                            <i class="bi bi-chevron-right stat-top-row__chev"></i>
+                        </a>
+                    @empty
+                        <div style="padding:0.75rem;text-align:center;color:var(--text-muted);font-size:0.8125rem;">Noch keine Lernabschnitte begonnen.</div>
+                    @endforelse
+                </div>
+            </div>
+
             <div class="glass p-4" style="border-radius: 0.75rem;">
                 <div class="text-xs uppercase tracking-wider mb-3" style="color: var(--text-muted);">
                     Lernabschnitte
@@ -67,6 +157,33 @@
 
         {{-- Sidebar --}}
         <div class="space-y-4">
+            {{-- 28-Tage Streak-Heatmap --}}
+            <div class="glass p-4" style="border-radius: 0.75rem;">
+                <div class="text-xs uppercase tracking-wider mb-3" style="color: var(--text-muted);">
+                    Streak · Letzte 28 Tage
+                </div>
+                <div class="stat-streak-hero">
+                    <div class="stat-streak-num">{{ $streakDays }}</div>
+                    <div class="stat-streak-label">Aktuelle Serie</div>
+                </div>
+                <div class="stat-heat-grid">
+                    @foreach($heatPattern as $v)
+                        <div class="stat-heat-cell" data-v="{{ $v }}"></div>
+                    @endforeach
+                </div>
+                <div class="stat-heat-legend">
+                    <span>Weniger</span>
+                    <div class="stat-heat-legend__scale">
+                        <div class="stat-heat-legend__swatch stat-heat-cell" data-v="0"></div>
+                        <div class="stat-heat-legend__swatch stat-heat-cell" data-v="1"></div>
+                        <div class="stat-heat-legend__swatch stat-heat-cell" data-v="2"></div>
+                        <div class="stat-heat-legend__swatch stat-heat-cell" data-v="3"></div>
+                        <div class="stat-heat-legend__swatch stat-heat-cell" data-v="4"></div>
+                    </div>
+                    <span>Mehr</span>
+                </div>
+            </div>
+
             {{-- Activity Chart --}}
             <div class="glass p-4" style="border-radius: 0.75rem;" x-data="{ view: 'week' }">
                 <div class="flex justify-between items-center mb-3">

--- a/routes/web.php
+++ b/routes/web.php
@@ -565,22 +565,24 @@ Route::middleware('auth')->group(function () {
             'streakDaysArr', 'heatPattern'
         ));
     })->name('profile');
-    Route::patch('/profile', function(Request $request) {
-        \Log::info('Profile route reached via PATCH');
-        return app(ProfileController::class)->update($request);
-    })->name('profile.update');
-    Route::patch('/profile/password', function(Request $request) {
-        \Log::info('Password update route reached via PATCH');
-        return app(ProfileController::class)->updatePassword($request);
-    })->name('profile.password.update');
+    // Profile-eigene Actions (Avatar, Accessoires, Dashboard-Banner) bleiben unter /profile
     Route::post('/profile/avatar/regenerate', [ProfileController::class, 'regenerateAvatar'])->name('profile.avatar.regenerate');
     Route::post('/profile/accessory/toggle', [ProfileController::class, 'toggleAccessory'])->name('profile.accessory.toggle');
     Route::post('/profile/accessory/color', [ProfileController::class, 'updateAccessoryColor'])->name('profile.accessory.color');
     Route::post('/profile/dismiss-leaderboard-banner', [ProfileController::class, 'dismissLeaderboardBanner'])->name('profile.dismiss.leaderboard.banner');
-    Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
-    Route::post('/profile/cancel-email-change', [ProfileController::class, 'cancelEmailChange'])->name('profile.cancel-email-change');
-    Route::post('/profile/extras-enabled', [ProfileController::class, 'updateExtrasEnabled'])->name('profile.extras-enabled');
-    Route::patch('/profile/notification-preferences', [ProfileController::class, 'updateNotificationPreferences'])->name('profile.notification-preferences');
+
+    // Einstellungen (Account-Verwaltung): Persönliche Daten, Passwort, Benachrichtigungen, Consents, Prüfungsdatum, Account löschen
+    Route::get('/einstellungen', function() {
+        $user = auth()->user()->fresh();
+        $ortsverbande = $user->ortsverbande()->get();
+        return view('einstellungen', compact('user', 'ortsverbande'));
+    })->name('einstellungen');
+    Route::patch('/einstellungen', [ProfileController::class, 'update'])->name('einstellungen.update');
+    Route::patch('/einstellungen/password', [ProfileController::class, 'updatePassword'])->name('einstellungen.password.update');
+    Route::delete('/einstellungen', [ProfileController::class, 'destroy'])->name('einstellungen.destroy');
+    Route::post('/einstellungen/cancel-email-change', [ProfileController::class, 'cancelEmailChange'])->name('einstellungen.cancel-email-change');
+    Route::post('/einstellungen/extras-enabled', [ProfileController::class, 'updateExtrasEnabled'])->name('einstellungen.extras-enabled');
+    Route::patch('/einstellungen/notification-preferences', [ProfileController::class, 'updateNotificationPreferences'])->name('einstellungen.notification-preferences');
 
     // Ausbildungsfortschritt (Issue #442)
     Route::get('/ausbildungsfortschritt', [TrainingProgressController::class, 'index'])->name('training-progress.index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -473,29 +473,15 @@ Route::post('/streak/freeze', [\App\Http\Controllers\GamificationController::cla
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', function() {
-        $user = auth()->user()->fresh(); // Fresh reload from database
+        $user = auth()->user()->fresh();
         $shopService = new \App\Services\ShopService();
         $ownedAccessories = $shopService->getOwnedAccessories($user);
         $gamification = new \App\Services\GamificationService();
         $levelProgress = $gamification->getLevelProgress($user);
         $nextLevelPoints = $gamification->getNextLevelPoints($user);
         $achievements = $gamification->getUserAchievements($user);
-        $ortsverbande = $user->ortsverbande()->get();
 
-        // Lernstatistik: Gesamt + Top-3 Lernabschnitte
-        $sectionNames = [
-            1 => 'Das THW im Gefüge des Zivil- und Katastrophenschutzes',
-            2 => 'Arbeitssicherheit und Gesundheitsschutz',
-            3 => 'Arbeiten mit Leinen, Drahtseilen, Ketten, Rund- und Bandschlingen',
-            4 => 'Arbeiten mit Leitern',
-            5 => 'Stromerzeugung und Beleuchtung',
-            6 => 'Metall-, Holz- und Steinbearbeitung',
-            7 => 'Bewegen von Lasten',
-            8 => 'Arbeiten am und auf dem Wasser',
-            9 => 'Einsatzgrundlagen',
-            10 => 'Grundlagen der Rettung und Bergung',
-        ];
-        // Lernstatistik — gleiche Datenquellen wie /user-statistik
+        // Stat-Pills: Gesamt-Übersicht
         $totalQuestions = \Illuminate\Support\Facades\Cache::remember('total_questions_count', 3600, fn () => \App\Models\Question::count());
         $solvedTotal = \App\Models\UserQuestionProgress::where('user_id', $user->id)->count();
         $totalAnswered = \App\Models\QuestionStatistic::where('user_id', $user->id)->count();
@@ -503,31 +489,7 @@ Route::middleware('auth')->group(function () {
         $hitRate = $totalAnswered > 0 ? (int) round(($totalCorrect / $totalAnswered) * 100) : null;
         $wrongTotal = max(0, $totalAnswered - $totalCorrect);
 
-        // Section-Fortschritt: gelöste (alle mit Progress) je Lernabschnitt
-        $questionsBySection = \App\Models\Question::selectRaw('lernabschnitt, COUNT(*) as total')
-            ->groupBy('lernabschnitt')->pluck('total', 'lernabschnitt');
-        $solvedBySection = \App\Models\UserQuestionProgress::where('user_id', $user->id)
-            ->join('questions', 'user_question_progress.question_id', '=', 'questions.id')
-            ->selectRaw('questions.lernabschnitt, COUNT(*) as cnt')
-            ->groupBy('questions.lernabschnitt')->pluck('cnt', 'lernabschnitt');
-        $sectionStats = [];
-        foreach ($sectionNames as $nr => $name) {
-            $total = (int) ($questionsBySection[$nr] ?? 0);
-            if ($total === 0) continue;
-            $solved = (int) ($solvedBySection[$nr] ?? 0);
-            $sectionStats[] = [
-                'nr' => $nr,
-                'name' => $name,
-                'total' => $total,
-                'solved' => $solved,
-                'percent' => $total > 0 ? (int) round(($solved / $total) * 100) : 0,
-            ];
-        }
-        $sectionsStarted = collect($sectionStats)->where('solved', '>', 0)->count();
-        $sectionsTotal = count($sectionStats);
-        $topSections = collect($sectionStats)->sortByDesc('solved')->take(3)->values()->all();
-
-        // 14-Tage Streak-Timeline: gleiche Logik wie Duolingo-Celebration (XP-History + Freeze-Log)
+        // 14-Tage Streak-Timeline für Hero-Card
         $firstXp = \App\Models\XpHistory::where('user_id', $user->id)->min('created_at');
         $firstLearnDate = $firstXp ? \Illuminate\Support\Carbon::parse($firstXp)->startOfDay() : null;
         $streakCalendar = app(\App\Services\GamificationService::class)->buildStreakCalendarData($user, 14);
@@ -543,26 +505,9 @@ Route::middleware('auth')->group(function () {
             ];
         }
 
-        // Heatmap (alter Code — bleibt für Streak-Card unten)
-        $heatmapStart = now()->subDays(27)->startOfDay();
-        $dailyCounts = \DB::table('user_question_progress')
-            ->where('user_id', $user->id)
-            ->where('last_answered_at', '>=', $heatmapStart)
-            ->selectRaw('DATE(last_answered_at) as d, COUNT(*) as c')
-            ->groupBy('d')->pluck('c', 'd')->toArray();
-        $heatPattern = [];
-        for ($i = 0; $i < 28; $i++) {
-            $date = now()->subDays(27 - $i)->format('Y-m-d');
-            $count = (int) ($dailyCounts[$date] ?? 0);
-            $intensity = $count === 0 ? 0 : ($count >= 20 ? 4 : ($count >= 10 ? 3 : ($count >= 5 ? 2 : 1)));
-            $heatPattern[] = $intensity;
-        }
-
         return view('profile', compact(
-            'user', 'ownedAccessories', 'levelProgress', 'nextLevelPoints', 'achievements', 'ortsverbande',
-            'totalQuestions', 'solvedTotal', 'wrongTotal', 'hitRate',
-            'topSections', 'sectionsStarted', 'sectionsTotal',
-            'streakDaysArr', 'heatPattern'
+            'user', 'ownedAccessories', 'levelProgress', 'nextLevelPoints', 'achievements',
+            'totalQuestions', 'solvedTotal', 'wrongTotal', 'hitRate', 'streakDaysArr'
         ));
     })->name('profile');
     // Profile-eigene Actions (Avatar, Accessoires, Dashboard-Banner) bleiben unter /profile


### PR DESCRIPTION
## Summary
This PR refactors the profile page by extracting account settings, security, notifications, and privacy controls into a dedicated `/einstellungen` (settings) page. The profile page now focuses on user identity, gamification progress, and achievements, while a new settings page handles all configuration options.

## Key Changes

- **New Settings Page** (`einstellungen.blade.php`): Created a dedicated settings page containing:
  - Personal data management (name, email, Ortsverband)
  - Exam date and extras configuration
  - Password management
  - Notification preferences with per-category toggles
  - Privacy and consent settings
  - Account metadata (creation date, last activity)
  - Danger zone with account deletion option

- **Simplified Profile Page** (`profile.blade.php`):
  - Removed settings-related cards (account, exam, security, notifications, privacy, meta, danger)
  - Removed streak heatmap and top sections list
  - Kept identity card, learning progress, and achievements
  - Updated page title and description to focus on "Avatar, Fortschritt und Achievements"
  - Added settings gear icon button linking to `/einstellungen`
  - Simplified status message handling to only show avatar-related feedback

- **Grid Layout Updates**:
  - Profile page: Adjusted grid spans for remaining cards (achievements now spans 4 instead of 6)
  - Settings page: Organized cards in 6-column layout with responsive behavior
  - Updated media queries for both pages

- **New UI Component**: Added `.pf-settings-gear` styled button with hover rotation effect for accessing settings

- **Route Updates** (`web.php`):
  - Profile route now only loads gamification and accessory data
  - Removed section statistics, heatmap, and metadata queries from profile
  - Settings route created to handle all configuration-related data

- **Controller Updates** (`ProfileController.php`, `StatisticsController.php`):
  - Moved section names mapping to `StatisticsController`
  - Updated profile update routes to use new settings endpoints
  - Maintained backward compatibility with existing update logic

## Implementation Details

- Settings page uses the same styling system and glass-morphism design as the profile
- Notification preferences support both email and push toggles per category
- Form submissions maintain CSRF protection and validation
- Responsive design ensures usability on mobile devices (stacks to single column below 1024px)
- Animation delays preserved for visual consistency

https://claude.ai/code/session_01KVLfKyrYgvsqmgYjcsoPwb