### PR TITLE
Add cross-platform font consistency to questions editor

### DIFF
--- a/resources/views/admin/questions/index.blade.php
+++ b/resources/views/admin/questions/index.blade.php
@@ -3,6 +3,8 @@
 @section('description', 'Bearbeite alle Fragen des THW-Trainer im Live-Editor.')
 
 @push('styles')
+<link rel="preconnect" href="https://fonts.bunny.net">
+<link href="https://fonts.bunny.net/css2?family=Figtree:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 <style>
 /* =========================================================
    FRAGEN-EDITOR · admin page
@@ -30,6 +32,10 @@ body.fq-fullbleed .min-h-screen { min-height: 100vh; }
     --fq-letter-fg:  var(--text-secondary);
     --fq-correct-bg: rgba(255,255,255,0.06);
     --fq-aside-bg:   var(--bg-elevated);
+
+    /* Cross-Platform Schriftarten — verhindert macOS↔Windows-Unterschiede */
+    --font-sans: 'Figtree', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    --font-mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', 'Cascadia Mono', Menlo, Consolas, monospace;
 }
 html.light-mode .fq-shell {
     --fq-surface:    #ffffff;


### PR DESCRIPTION
## Summary
This PR adds web fonts and CSS custom properties to ensure consistent typography across different operating systems in the questions editor admin page.

## Key Changes
- Added Bunny Fonts CDN links for Figtree (sans-serif) and IBM Plex Mono (monospace) fonts
- Introduced two new CSS custom properties:
  - `--font-sans`: Figtree with system font fallbacks for cross-platform consistency
  - `--font-mono`: IBM Plex Mono with system font fallbacks
- Added explanatory comment noting the purpose: preventing macOS↔Windows font rendering differences

## Implementation Details
The fonts are loaded from Bunny Fonts (privacy-friendly alternative to Google Fonts) with a preconnect link for performance optimization. The custom properties follow a fallback chain that prioritizes the web fonts while gracefully degrading to system fonts if needed.

https://claude.ai/code/session_01THoccxHpGQXtqiXUUFuPjH