### PR TITLE
Restrict email preview routes to non-production with admin auth

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -833,9 +833,9 @@ if (config('app.debug')) {
 Route::get('/exam-feedback/{token}', [\App\Http\Controllers\ExamFeedbackController::class, 'show'])->name('exam-feedback.show');
 Route::post('/exam-feedback/{token}', [\App\Http\Controllers\ExamFeedbackController::class, 'store'])->name('exam-feedback.store');
 
-// Email Template Preview (nur lokal)
-if (app()->environment('local')) {
-    Route::prefix('dev/email-preview')->group(function () {
+// Email Template Preview (nur Non-Production, Admin-only)
+if (!app()->environment('production')) {
+    Route::middleware(['auth', \App\Http\Middleware\AdminMiddleware::class])->prefix('dev/email-preview')->group(function () {
         $templates = [
             'account-deleted', 'account-deletion-warning', 'admin-daily-report',
             'contact', 'data-export', 'exam-feedback-request', 'exam-goodluck',


### PR DESCRIPTION
## Summary
Enhanced security for the email template preview routes by restricting access to non-production environments only and requiring admin authentication.

## Key Changes
- Changed environment check from `local` only to `!production`, allowing access in staging/development environments
- Added authentication middleware requirement (`auth`) to email preview routes
- Added admin-only middleware (`AdminMiddleware`) to ensure only administrators can access email previews
- Updated inline comment to reflect the new access restrictions

## Implementation Details
The email preview routes are now protected by:
1. Environment restriction: Routes are only available outside of production
2. Authentication: Users must be logged in
3. Authorization: Users must have admin privileges via the `AdminMiddleware`

This maintains developer/admin access to email templates while preventing unauthorized access in production environments.

https://claude.ai/code/session_01HQuoD97xmm3q1i1jrmtJXR