### PR TITLE
chore: remove generic sonderausbildung

### DIFF
--- a/app/Services/TrainingProgressService.php
+++ b/app/Services/TrainingProgressService.php
@@ -142,7 +142,6 @@ class TrainingProgressService
         ['key' => 'zusatz.g26', 'label' => 'G26.1'],
         ['key' => 'zusatz.funk', 'label' => 'Funk'],
         ['key' => 'zusatz.knotenkunde', 'label' => 'Knotenkunde'],
-        ['key' => 'zusatz.sonder', 'label' => 'Sonderausbildung'],
     ];
 
     /**

--- a/database/migrations/2026_05_05_100000_remove_sonderausbildung_from_user_training_progress.php
+++ b/database/migrations/2026_05_05_100000_remove_sonderausbildung_from_user_training_progress.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('user_training_progress')
+            ->where('item_key', 'zusatz.sonder')
+            ->delete();
+    }
+
+    public function down(): void
+    {
+        // No-op: deleted progress entries cannot be restored.
+    }
+};


### PR DESCRIPTION
Nach Rücksprache mit unserem AB kann "Sonderausbildung" gestrichen werden, das wurde in Papierform auch nie befüllt und sorgt in der digitalen Variante dafür, dass man nie 100% erreichen kann