### PR TITLE
chore: fix raw json output on notifications route

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -50,7 +50,7 @@ class NotificationController extends Controller
     /**
      * Markiert alle Notifications als gelesen
      */
-    public function markAllAsRead()
+    public function markAllAsRead(Request $request)
     {
         auth()->user()
             ->unreadNotifications()
@@ -59,7 +59,11 @@ class NotificationController extends Controller
                 'read_at' => now(),
             ]);
 
-        return response()->json(['success' => true]);
+        if ($request->wantsJson() || $request->ajax()) {
+            return response()->json(['success' => true]);
+        }
+
+        return back()->with('success', 'Alle Mitteilungen wurden als gelesen markiert.');
     }
 
     /**


### PR DESCRIPTION
Ein Klick auf "Alle gelesen" öffnete die Route `/notifications/read-all` und spuckte eine rohe JSON Response aus. Der Fix behebt das, indem er den Counter zurücksetzt und auf der Seite bleibt