### PR TITLE
🎨: Contributor Dashboard 1:1 wie Admin

### DIFF
--- a/app/Http/Controllers/Contributor/DashboardController.php
+++ b/app/Http/Controllers/Contributor/DashboardController.php
@@ -9,6 +9,7 @@ use App\Models\LehrgangQuestionIssue;
 use App\Models\Question;
 use App\Models\QuestionIssue;
 use App\Models\UserExtraQuestionSubmission;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 
 class DashboardController extends Controller
@@ -16,26 +17,180 @@ class DashboardController extends Controller
     public function index()
     {
         return view('contributor.dashboard', [
-            'stats'              => $this->getStats(),
-            'handlungsbedarf'    => $this->getHandlungsbedarf(),
-            'recentSubmissions'  => $this->getRecentSubmissions(),
-            'submissionStats'    => $this->getSubmissionStats(),
-            'topFalsch'          => $this->getTopQuestions('wrong'),
-            'topRichtig'         => $this->getTopQuestions('correct'),
-            'recentIssues'       => $this->getRecentIssues(),
+            'statusBar'         => $this->getStatusBar(),
+            'kpis'              => $this->getKpis(),
+            'handlungsbedarf'   => $this->getHandlungsbedarf(),
+            'recentSubmissions' => $this->getRecentSubmissions(),
+            'submissionStats'   => $this->getSubmissionStats(),
+            'fragenQualitaet'   => $this->getFragenQualitaet(),
+            'recentIssues'      => $this->getRecentIssues(),
         ]);
     }
 
-    private function getStats(): array
+    /* =========================================================
+       STATUS BAR — analog zur System-Puls Bar im Admin Dashboard
+       ========================================================= */
+    private function getStatusBar(): array
     {
+        $totalFragen      = Question::count();
+        $entwuerfe        = Question::whereNull('loesung')->orWhere('loesung', '')->count();
+        $totalExtra       = ExtraQuestion::count();
+        $pendingSubmissions = UserExtraQuestionSubmission::where('status', 'pending')->count();
+        $openIssues       = QuestionIssue::where('status', 'open')->count()
+                          + LehrgangQuestionIssue::where('status', 'open')->count();
+        $totalLehrgaenge  = Lehrgang::count();
+
         return [
-            'fragen'         => Question::count(),
-            'extraFragen'    => ExtraQuestion::count(),
-            'lehrgaenge'     => Lehrgang::count(),
-            'entwuerfe'      => Question::whereNull('loesung')->orWhere('loesung', '')->count(),
+            'fragen' => [
+                'status' => $entwuerfe > 0 ? 'warn' : 'ok',
+                'label'  => 'Fragen-Pool',
+                'value'  => number_format($totalFragen, 0, ',', '.'),
+                'sub'    => $entwuerfe . ' ' . ($entwuerfe === 1 ? 'Entwurf' : 'Entwürfe'),
+                'link'   => route('admin.questions.index'),
+            ],
+            'zusatz' => [
+                'status' => $pendingSubmissions >= 3 ? 'warn' : 'ok',
+                'label'  => 'Zusatz-Fragen',
+                'value'  => number_format($totalExtra, 0, ',', '.'),
+                'sub'    => $pendingSubmissions . ' ' . ($pendingSubmissions === 1 ? 'Vorschlag offen' : 'Vorschläge offen'),
+                'link'   => route('admin.extra-question-submissions.index', ['status' => 'pending']),
+            ],
+            'lehrgaenge' => [
+                'status' => 'ok',
+                'label'  => 'Lehrgänge',
+                'value'  => number_format($totalLehrgaenge, 0, ',', '.'),
+                'sub'    => 'Kurse zum Bearbeiten',
+                'link'   => route('admin.lehrgaenge.index'),
+            ],
+            'issues' => [
+                'status' => $openIssues === 0 ? 'ok' : ($openIssues >= 5 ? 'err' : 'warn'),
+                'label'  => 'Fehlermeldungen',
+                'value'  => $openIssues === 0 ? 'Keine offen' : $openIssues . ' offen',
+                'sub'    => 'Issues zur Bearbeitung',
+                'link'   => route('admin.issues.index'),
+            ],
         ];
     }
 
+    /* =========================================================
+       KPI CARDS — Wert + Sparkline (letzte 14 Tage Trend)
+       ========================================================= */
+    private function getKpis(): array
+    {
+        return [
+            'fragen'     => $this->kpiFragen(),
+            'extra'      => $this->kpiExtra(),
+            'lehrgaenge' => $this->kpiLehrgaenge(),
+            'entwuerfe'  => $this->kpiEntwuerfe(),
+            'vorschlaege' => $this->kpiVorschlaege(),
+        ];
+    }
+
+    private function kpiFragen(): array
+    {
+        $total = Question::count();
+        $before = Question::where('created_at', '<', now()->subDays(30))->count();
+
+        $spark = [];
+        for ($i = 13; $i >= 0; $i--) {
+            $spark[] = Question::where('created_at', '<=', now()->subDays($i)->endOfDay())->count();
+        }
+
+        return [
+            'label' => 'Fragen gesamt',
+            'value' => number_format($total, 0, ',', '.'),
+            'delta' => $this->formatDelta($total - $before),
+            'spark' => $spark,
+            'color' => 'blue',
+        ];
+    }
+
+    private function kpiExtra(): array
+    {
+        $total = ExtraQuestion::count();
+        $before = ExtraQuestion::where('created_at', '<', now()->subDays(30))->count();
+
+        $spark = [];
+        for ($i = 13; $i >= 0; $i--) {
+            $spark[] = ExtraQuestion::where('created_at', '<=', now()->subDays($i)->endOfDay())->count();
+        }
+
+        return [
+            'label' => 'Zusatz-Fragen',
+            'value' => number_format($total, 0, ',', '.'),
+            'delta' => $this->formatDelta($total - $before),
+            'spark' => $spark,
+        ];
+    }
+
+    private function kpiLehrgaenge(): array
+    {
+        $total = Lehrgang::count();
+
+        $spark = array_fill(0, 14, $total);
+
+        return [
+            'label' => 'Lehrgänge',
+            'value' => number_format($total, 0, ',', '.'),
+            'delta' => $this->formatDelta(0),
+            'spark' => $spark,
+        ];
+    }
+
+    private function kpiEntwuerfe(): array
+    {
+        $current = Question::whereNull('loesung')->orWhere('loesung', '')->count();
+
+        $spark = array_fill(0, 14, $current);
+
+        return [
+            'label' => 'Entwürfe',
+            'value' => number_format($current, 0, ',', '.'),
+            'delta' => $this->formatDelta(0),
+            'spark' => $spark,
+            'color' => $current === 0 ? 'ok' : null,
+        ];
+    }
+
+    private function kpiVorschlaege(): array
+    {
+        $pending = UserExtraQuestionSubmission::where('status', 'pending')->count();
+
+        $spark = [];
+        for ($i = 13; $i >= 0; $i--) {
+            $day = now()->subDays($i);
+            $spark[] = UserExtraQuestionSubmission::where('created_at', '<=', $day->endOfDay())
+                ->where('status', 'pending')
+                ->count();
+        }
+
+        $previous = UserExtraQuestionSubmission::where('created_at', '<=', now()->subDays(7)->endOfDay())
+            ->where('status', 'pending')
+            ->count();
+
+        return [
+            'label' => 'Offene Vorschläge',
+            'value' => number_format($pending, 0, ',', '.'),
+            'delta' => $this->formatDelta($pending - $previous),
+            'spark' => $spark,
+        ];
+    }
+
+    private function formatDelta(int $value): array
+    {
+        $sign = $value > 0 ? '+' : ($value < 0 ? '−' : '');
+        $abs = abs($value);
+        $direction = $value > 0 ? 'up' : ($value < 0 ? 'down' : 'flat');
+
+        return [
+            'direction' => $direction,
+            'text'      => $direction === 'flat' ? 'unverändert' : $sign . number_format($abs, 0, ',', '.') . ' · 30 T',
+        ];
+    }
+
+    /* =========================================================
+       HANDLUNGSBEDARF — priorisierte Queue (nur Contributor-Themen)
+       ========================================================= */
     private function getHandlungsbedarf(): array
     {
         $queue = [];
@@ -47,10 +202,15 @@ class DashboardController extends Controller
                 optional(QuestionIssue::where('status', 'open')->latest()->first())->created_at,
                 optional(LehrgangQuestionIssue::where('status', 'open')->latest()->first())->created_at,
             );
+            $oldest = min(
+                optional(QuestionIssue::where('status', 'open')->oldest()->first())->created_at ?: now(),
+                optional(LehrgangQuestionIssue::where('status', 'open')->oldest()->first())->created_at ?: now(),
+            );
             $queue[] = [
                 'count'  => $openBugs,
                 'title'  => 'Fehlermeldungen',
-                'sub'    => 'offen · neueste ' . ($newest ? $newest->diffForHumans() : 'unbekannt'),
+                'sub'    => 'neueste ' . ($newest ? $newest->diffForHumans() : 'unbekannt')
+                          . ' · älteste ' . ($oldest ? $oldest->diffForHumans() : 'unbekannt'),
                 'link'   => route('admin.issues.index'),
                 'variant' => 'red',
                 'urgent' => $openBugs >= 3,
@@ -85,7 +245,10 @@ class DashboardController extends Controller
         return $queue;
     }
 
-    private function getRecentSubmissions(int $limit = 6): array
+    /* =========================================================
+       RECENT SUBMISSIONS
+       ========================================================= */
+    private function getRecentSubmissions(int $limit = 8): array
     {
         return UserExtraQuestionSubmission::with('user')
             ->latest()
@@ -100,7 +263,7 @@ class DashboardController extends Controller
                     'status'        => $s->status,
                     'status_label'  => $s->statusLabel(),
                     'user_name'     => $s->user->name ?? 'Unbekannt',
-                    'created_human' => $s->created_at->diffForHumans(),
+                    'created_human' => $s->created_at->diffForHumans(null, true, true),
                 ];
             })
             ->all();
@@ -117,15 +280,48 @@ class DashboardController extends Controller
         ];
     }
 
-    /**
-     * Top 3 Fragen nach Korrekt-/Falsch-Quote (mindestens 10 Versuche, letzte 30 Tage).
-     *
-     * @param 'correct'|'wrong' $mode
-     */
-    private function getTopQuestions(string $mode): array
+    /* =========================================================
+       FRAGEN-QUALITÄT — analog Admin Dashboard
+       ========================================================= */
+    private function getFragenQualitaet(): array
     {
         $from = now()->subDays(30);
 
+        $sources = [
+            'question_statistics',
+            'lehrgang_question_statistics',
+            'ortsverband_lernpool_question_statistics',
+        ];
+
+        $totalAnswered = 0;
+        $correct = 0;
+        foreach ($sources as $table) {
+            $totalAnswered += DB::table($table)->where('created_at', '>=', $from)->count();
+            $correct       += DB::table($table)->where('created_at', '>=', $from)->where('is_correct', true)->count();
+        }
+        $wrong = $totalAnswered - $correct;
+        $successRate = $totalAnswered > 0 ? round(($correct / $totalAnswered) * 100, 1) : 0;
+
+        $totalFragen = Question::count();
+        $entwuerfe = Question::whereNull('loesung')->orWhere('loesung', '')->count();
+
+        return [
+            'correct'      => $correct,
+            'wrong'        => $wrong,
+            'totalAnswered' => $totalAnswered,
+            'successRate'  => $successRate,
+            'totalFragen'  => $totalFragen,
+            'entwuerfe'    => $entwuerfe,
+            'topRichtig'   => $this->topQuestions('correct', $from),
+            'topFalsch'    => $this->topQuestions('wrong', $from),
+        ];
+    }
+
+    /**
+     * @param 'correct'|'wrong' $mode
+     */
+    private function topQuestions(string $mode, Carbon $from): array
+    {
         $rows = DB::table('question_statistics')
             ->join('questions', 'question_statistics.question_id', '=', 'questions.id')
             ->where('question_statistics.created_at', '>=', $from)
@@ -164,13 +360,16 @@ class DashboardController extends Controller
     private function shortenFrage(?string $text): string
     {
         $text = trim(strip_tags($text ?? ''));
-        if (mb_strlen($text) <= 60) {
+        if (mb_strlen($text) <= 40) {
             return $text;
         }
-        return mb_substr($text, 0, 57) . '…';
+        return mb_substr($text, 0, 37) . '…';
     }
 
-    private function getRecentIssues(int $limit = 4): array
+    /* =========================================================
+       RECENT ISSUES
+       ========================================================= */
+    private function getRecentIssues(int $limit = 6): array
     {
         $issues = QuestionIssue::with('question')
             ->where('status', 'open')
@@ -186,7 +385,7 @@ class DashboardController extends Controller
                         ? mb_substr(strip_tags($i->question->frage), 0, 80)
                         : null,
                     'created_at'    => $i->created_at,
-                    'created_human' => $i->created_at->diffForHumans(),
+                    'created_human' => $i->created_at->diffForHumans(null, true, true),
                 ];
             });
 
@@ -201,7 +400,7 @@ class DashboardController extends Controller
                     'title'         => 'Lehrgang-Issue #' . $i->id,
                     'frage'         => null,
                     'created_at'    => $i->created_at,
-                    'created_human' => $i->created_at->diffForHumans(),
+                    'created_human' => $i->created_at->diffForHumans(null, true, true),
                 ];
             });
 

--- a/resources/views/contributor/dashboard.blade.php
+++ b/resources/views/contributor/dashboard.blade.php
@@ -1,471 +1,721 @@
 @extends('layouts.app')
 
 @section('title', 'Contributor Dashboard')
-@section('description', 'Übersicht: Fragen pflegen, Einreichungen sichten, Fehlermeldungen bearbeiten')
+@section('description', 'Fragen pflegen, Einreichungen sichten und Fehlermeldungen bearbeiten')
 
 @push('styles')
 <style>
 /* =========================================================
-   CONTRIBUTOR DASHBOARD — eigene, ergänzende Tokens
-   Reuses .dash-container / .glass-* / .stat-pill / .bento-grid
-   aus app.css. Hier nur dashboard-spezifische Helfer.
+   CONTRIBUTOR DASHBOARD — 1:1 Design wie Admin Dashboard
+   Nutzt dieselben Tokens (var(--thw-blue-glow), --glass-bg, …)
+   und dieselben Klassennamen — gescoped via .admin-root.
    ========================================================= */
 
-.contrib-queue-row {
-    display: flex; align-items: center; gap: 0.875rem;
-    padding: 0.75rem 0.875rem; border-radius: 0.625rem;
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    background: transparent; text-decoration: none; color: inherit;
-    transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
-}
-html.light-mode .contrib-queue-row { border-color: rgba(0, 51, 127, 0.08); }
-.contrib-queue-row:hover {
-    border-color: rgba(91, 154, 255, 0.35);
-    background: rgba(255, 255, 255, 0.04);
-    transform: translateX(2px);
-}
-html.light-mode .contrib-queue-row:hover { background: rgba(0, 51, 127, 0.03); }
-.contrib-queue-row--urgent { border-color: rgba(239, 68, 68, 0.30); }
-.contrib-queue-row--urgent:hover { border-color: rgba(239, 68, 68, 0.50); }
-.contrib-queue-count {
-    width: 42px; height: 42px; flex-shrink: 0; border-radius: 10px;
-    display: grid; place-items: center;
-    font-family: 'Figtree', sans-serif; font-weight: 800; font-size: 1.125rem;
-    letter-spacing: -0.02em;
-}
-.contrib-queue-count--red   { background: rgba(239, 68, 68, 0.14);  color: #ef4444; }
-.contrib-queue-count--gold  { background: rgba(251, 191, 36, 0.14); color: #fbbf24; }
-.contrib-queue-count--purp  { background: rgba(167, 139, 250, 0.14); color: #a78bfa; }
-.contrib-queue-count--blue  { background: rgba(91, 154, 255, 0.14); color: #5b9aff; }
-html.light-mode .contrib-queue-count--blue { color: var(--thw-blue); }
-.contrib-queue-body { flex: 1; min-width: 0; }
-.contrib-queue-title { font-size: 0.9375rem; font-weight: 700; color: var(--text-primary); margin-bottom: 0.125rem; }
-.contrib-queue-sub { font-size: 0.75rem; color: var(--text-muted); }
-.contrib-queue-arrow { color: var(--text-muted); font-size: 0.875rem; flex-shrink: 0; }
+/* Container */
+.admin-root { width: 100%; max-width: 1280px; margin: 0 auto; }
 
-.contrib-section-label {
-    display: inline-block; font-family: 'IBM Plex Mono', monospace;
-    font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
-    letter-spacing: 0.1em; color: var(--text-muted);
+/* Header */
+.admin-root .admin-header {
+    display: flex; align-items: flex-end; justify-content: space-between;
+    gap: 1.5rem; flex-wrap: wrap; margin-bottom: 1.5rem;
 }
-.contrib-card-h {
+.admin-root .admin-header__right { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+
+.admin-root .admin-page-title { margin: 0; }
+.admin-root .admin-page-title__eyebrow {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.75rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.1em;
+    color: var(--text-muted); margin-bottom: 0.35rem;
+}
+.admin-root .admin-page-title__h1 {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-weight: 800; font-size: 2rem; line-height: 1.1;
+    letter-spacing: -0.015em;
+    color: #5b9aff; margin: 0 0 0.25rem;
+}
+html.light-mode .admin-root .admin-page-title__h1 { color: var(--thw-blue); }
+.admin-root .admin-page-title__sub { font-size: 0.9375rem; color: var(--text-secondary); margin: 0; }
+
+.admin-root .icon-btn-outline {
+    display: inline-flex; align-items: center; gap: 0.5rem;
+    padding: 0.5rem 0.875rem; border-radius: 0.5rem;
+    background: var(--glass-bg); border: 1px solid var(--glass-border);
+    color: var(--text-secondary); font-size: 0.8125rem; font-weight: 600;
+    text-decoration: none; cursor: pointer;
+    transition: border-color var(--transition-fast), color var(--transition-fast);
+}
+.admin-root .icon-btn-outline:hover { border-color: #5b9aff; color: var(--text-primary); }
+.admin-root .icon-btn-outline .bi { color: #5b9aff; }
+html.light-mode .admin-root .icon-btn-outline .bi { color: var(--thw-blue); }
+
+/* Status bar (analog System-Puls) */
+.admin-root .sys-pulse {
+    display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem;
+    padding: 0.875rem 1rem; border-radius: 0.875rem;
+    background: var(--glass-bg); border: 1px solid var(--glass-border);
+    margin-bottom: 1.25rem;
+}
+.admin-root .pulse-item { display: flex; align-items: center; gap: 0.75rem; min-width: 0; }
+.admin-root a.pulse-item { text-decoration: none; color: inherit; }
+.admin-root .pulse-item--link { cursor: pointer; transition: color var(--transition-fast); }
+.admin-root .pulse-item--link:hover .pulse-value { color: #5b9aff; }
+.admin-root .pulse-item--link:hover .pulse-chevron { color: #5b9aff; transform: translateX(2px); }
+html.light-mode .admin-root .pulse-item--link:hover .pulse-value { color: var(--thw-blue); }
+html.light-mode .admin-root .pulse-item--link:hover .pulse-chevron { color: var(--thw-blue); }
+.admin-root .pulse-chevron { margin-left: auto; color: var(--text-muted); font-size: 0.875rem; transition: transform var(--transition-fast), color var(--transition-fast); flex-shrink: 0; }
+.admin-root .pulse-item + .pulse-item { border-left: 1px solid rgba(255,255,255,0.06); padding-left: 0.875rem; }
+html.light-mode .admin-root .pulse-item + .pulse-item { border-left-color: rgba(0,51,127,0.08); }
+.admin-root .pulse-dot {
+    width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0;
+    box-shadow: 0 0 0 3px rgba(34,197,94,0.2);
+}
+.admin-root .pulse-dot--ok   { background: #22c55e; box-shadow: 0 0 0 3px rgba(34,197,94,0.25); animation: pulseDot 2.4s ease-in-out infinite; }
+.admin-root .pulse-dot--warn { background: #f59e0b; box-shadow: 0 0 0 3px rgba(245,158,11,0.25); }
+.admin-root .pulse-dot--err  { background: #ef4444; box-shadow: 0 0 0 3px rgba(239,68,68,0.25); }
+@keyframes pulseDot {
+    0%, 100% { box-shadow: 0 0 0 3px rgba(34,197,94,0.25); }
+    50%      { box-shadow: 0 0 0 6px rgba(34,197,94,0); }
+}
+.admin-root .pulse-meta { min-width: 0; line-height: 1.2; }
+.admin-root .pulse-label {
+    font-family: 'IBM Plex Mono', monospace; font-size: 0.625rem; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted);
+    margin-bottom: 0.15rem;
+}
+.admin-root .pulse-value {
+    font-family: 'Figtree', sans-serif; font-weight: 700; font-size: 0.875rem;
+    color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.admin-root .pulse-sub { font-size: 0.6875rem; color: var(--text-muted); }
+
+/* KPI row */
+.admin-root .kpi-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 0.75rem; margin-bottom: 1.25rem; }
+.admin-root .kpi {
+    position: relative; padding: 1rem 1.125rem;
+    border-radius: 0.875rem;
+    background: var(--glass-bg); border: 1px solid var(--glass-border);
+    overflow: hidden;
+}
+html.light-mode .admin-root .kpi { background: #fff; box-shadow: 0 1px 3px rgba(0,51,127,0.04); }
+.admin-root .kpi__label {
+    font-family: 'IBM Plex Mono', monospace; font-size: 0.625rem; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted);
+    margin-bottom: 0.375rem;
+}
+.admin-root .kpi__value {
+    font-family: 'Figtree', sans-serif; font-weight: 800; font-size: 1.875rem;
+    line-height: 1.05; letter-spacing: -0.015em; color: var(--text-primary);
+}
+.admin-root .kpi__value--blue { color: #5b9aff; }
+html.light-mode .admin-root .kpi__value--blue { color: var(--thw-blue); }
+.admin-root .kpi__value--ok { color: #22c55e; }
+.admin-root .kpi__delta {
+    margin-top: 0.5rem; display: inline-flex; align-items: center; gap: 0.25rem;
+    padding: 0.1rem 0.5rem 0.12rem; border-radius: 999px;
+    font-family: 'IBM Plex Mono', monospace; font-size: 0.625rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.08em;
+}
+.admin-root .kpi__delta--up   { color: #22c55e; background: rgba(34,197,94,0.12); }
+.admin-root .kpi__delta--down { color: #ef4444; background: rgba(239,68,68,0.12); }
+.admin-root .kpi__delta--flat { color: var(--text-muted); background: var(--glass-bg); border: 1px solid rgba(255,255,255,0.06); }
+html.light-mode .admin-root .kpi__delta--flat { border-color: rgba(0,51,127,0.08); }
+.admin-root .kpi__spark { position: absolute; right: 0.6rem; bottom: 0.6rem; width: 74px; height: 28px; opacity: 0.85; }
+
+/* Two-column bento */
+.admin-root .admin-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem; }
+.admin-root .admin-grid--wide  { grid-template-columns: minmax(0,1.5fr) minmax(0,1fr); }
+
+.admin-root .card {
+    background: var(--glass-bg); border: 1px solid var(--glass-border);
+    border-radius: 0.875rem; padding: 1.25rem;
+}
+html.light-mode .admin-root .card { background: #fff; box-shadow: 0 1px 3px rgba(0,51,127,0.04); }
+
+.admin-root .card-h {
     display: flex; align-items: center; justify-content: space-between;
     gap: 0.75rem; margin-bottom: 1rem; flex-wrap: wrap;
 }
-.contrib-card-h-link {
+.admin-root .card-h-actions { display: flex; gap: 0.5rem; align-items: center; }
+.admin-root .card-h-link {
     font-family: 'IBM Plex Mono', monospace; font-size: 0.6875rem; font-weight: 600;
     text-transform: uppercase; letter-spacing: 0.08em; color: #5b9aff;
     text-decoration: none;
 }
-html.light-mode .contrib-card-h-link { color: var(--thw-blue); }
-.contrib-card-h-link:hover { color: var(--gold-start); }
+html.light-mode .admin-root .card-h-link { color: var(--thw-blue); }
+.admin-root .card-h-link:hover { color: var(--gold); }
 
-/* Quick links list (sidebar) */
-.contrib-quick-list { display: flex; flex-direction: column; gap: 0.5rem; }
-.contrib-quick-link {
-    display: flex; align-items: center; gap: 0.75rem;
-    padding: 0.625rem 0.875rem; border-radius: 0.5rem;
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    text-decoration: none; color: inherit;
-    transition: border-color 150ms ease, background 150ms ease;
+.admin-root .section-label {
+    display: inline-block; font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.1em; color: var(--text-muted);
 }
-html.light-mode .contrib-quick-link { border-color: rgba(0, 51, 127, 0.08); }
-.contrib-quick-link:hover {
-    border-color: rgba(91, 154, 255, 0.4);
-    background: rgba(91, 154, 255, 0.05);
-}
-.contrib-quick-link .bi { color: #5b9aff; font-size: 1rem; flex-shrink: 0; }
-html.light-mode .contrib-quick-link .bi { color: var(--thw-blue); }
-.contrib-quick-link__title { font-size: 0.875rem; font-weight: 600; color: var(--text-primary); }
-.contrib-quick-link__sub { font-size: 0.6875rem; color: var(--text-muted); }
-.contrib-quick-link > div:first-of-type { flex: 1; min-width: 0; }
-.contrib-quick-link > .bi-chevron-right { font-size: 0.75rem; color: var(--text-muted); }
+html.light-mode .admin-root .section-label { color: #6b7280; }
 
-/* Submission row */
-.contrib-sub-row {
-    display: flex; align-items: flex-start; gap: 0.75rem;
+/* Feed (Submissions / Issues) */
+.admin-root .feed {
+    display: flex; flex-direction: column; max-height: 360px; overflow-y: auto;
+    margin: -0.25rem; padding: 0 0.25rem;
+}
+.admin-root .feed-item {
+    display: flex; gap: 0.75rem; align-items: flex-start;
     padding: 0.625rem 0.25rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    border-bottom: 1px solid rgba(255,255,255,0.06);
     text-decoration: none; color: inherit;
 }
-html.light-mode .contrib-sub-row { border-bottom-color: rgba(0, 51, 127, 0.08); }
-.contrib-sub-row:last-child { border-bottom: 0; }
-.contrib-sub-row:hover .contrib-sub-frage { color: #5b9aff; }
-html.light-mode .contrib-sub-row:hover .contrib-sub-frage { color: var(--thw-blue); }
-.contrib-sub-body { flex: 1; min-width: 0; }
-.contrib-sub-frage {
-    font-size: 0.8125rem; color: var(--text-primary); line-height: 1.35;
-    font-weight: 500;
-    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
-    overflow: hidden;
+html.light-mode .admin-root .feed-item { border-bottom-color: rgba(0,51,127,0.08); }
+.admin-root .feed-item:last-child { border-bottom: 0; }
+.admin-root a.feed-item:hover .feed-text strong { color: #5b9aff; }
+html.light-mode .admin-root a.feed-item:hover .feed-text strong { color: var(--thw-blue); }
+.admin-root .feed-icon {
+    width: 28px; height: 28px; border-radius: 8px;
+    display: grid; place-items: center; font-size: 0.8125rem; flex-shrink: 0;
 }
-.contrib-sub-meta {
-    margin-top: 0.25rem;
-    font-family: 'IBM Plex Mono', monospace; font-size: 0.625rem;
-    color: var(--text-muted); letter-spacing: 0.02em;
+.admin-root .feed-icon--blue  { background: rgba(91,154,255,0.14); color: #5b9aff; }
+.admin-root .feed-icon--green { background: rgba(34,197,94,0.14);  color: #22c55e; }
+.admin-root .feed-icon--gold  { background: rgba(251,191,36,0.14); color: #fbbf24; }
+.admin-root .feed-icon--red   { background: rgba(239,68,68,0.14);  color: #ef4444; }
+.admin-root .feed-icon--purple{ background: rgba(167,139,250,0.14); color: #a78bfa; }
+html.light-mode .admin-root .feed-icon--blue { color: var(--thw-blue); }
+.admin-root .feed-body { flex: 1; min-width: 0; }
+.admin-root .feed-text { font-size: 0.8125rem; color: var(--text-primary); line-height: 1.4; }
+.admin-root .feed-text strong { font-weight: 700; color: var(--text-primary); transition: color var(--transition-fast); }
+.admin-root .feed-text .muted { color: var(--text-muted); }
+.admin-root .feed-meta { display: flex; gap: 0.625rem; margin-top: 0.25rem; align-items: center; }
+.admin-root .feed-time {
+    font-family: 'IBM Plex Mono', monospace; font-size: 0.625rem; font-weight: 600;
+    color: var(--text-muted); letter-spacing: 0.03em;
 }
-.contrib-status {
-    flex-shrink: 0; padding: 0.15rem 0.5rem;
-    border-radius: 999px;
+.admin-root .feed-tag {
     font-family: 'IBM Plex Mono', monospace; font-size: 0.625rem; font-weight: 700;
-    text-transform: uppercase; letter-spacing: 0.05em;
-    white-space: nowrap;
+    text-transform: uppercase; letter-spacing: 0.08em;
+    padding: 0.05rem 0.45rem; border-radius: 999px;
+    background: var(--glass-bg); color: var(--text-muted);
+    border: 1px solid rgba(255,255,255,0.06);
 }
-.contrib-status--pending  { background: rgba(91, 154, 255, 0.14); color: #5b9aff; }
-.contrib-status--approved { background: rgba(34, 197, 94, 0.14);  color: #22c55e; }
-.contrib-status--changed  { background: rgba(251, 191, 36, 0.14); color: #fbbf24; }
-.contrib-status--rejected { background: rgba(239, 68, 68, 0.14);  color: #ef4444; }
-html.light-mode .contrib-status--pending  { color: var(--thw-blue); }
+html.light-mode .admin-root .feed-tag { border-color: rgba(0,51,127,0.08); }
+.admin-root .feed-tag--pending  { color: #5b9aff; border-color: rgba(91,154,255,0.30); background: rgba(91,154,255,0.08); }
+.admin-root .feed-tag--approved { color: #22c55e; border-color: rgba(34,197,94,0.30);  background: rgba(34,197,94,0.08); }
+.admin-root .feed-tag--changed  { color: #fbbf24; border-color: rgba(251,191,36,0.30); background: rgba(251,191,36,0.08); }
+.admin-root .feed-tag--rejected { color: #ef4444; border-color: rgba(239,68,68,0.30);  background: rgba(239,68,68,0.08); }
 
-/* Question rows (Top Falsch/Richtig) */
-.contrib-q-row {
-    display: flex; align-items: center; gap: 0.625rem;
-    padding: 0.5rem 0.625rem; border-radius: 0.5rem;
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    text-decoration: none; color: inherit;
-    margin-bottom: 0.375rem;
-    transition: border-color 150ms ease;
+/* Handlungsbedarf queue */
+.admin-root .queue-list { display: flex; flex-direction: column; gap: 0.5rem; }
+.admin-root .queue-row {
+    display: flex; align-items: center; gap: 0.875rem;
+    padding: 0.75rem 0.875rem; border-radius: 0.625rem;
+    border: 1px solid rgba(255,255,255,0.06);
+    background: transparent; text-decoration: none; color: inherit;
+    transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
 }
-html.light-mode .contrib-q-row { border-color: rgba(0, 51, 127, 0.08); }
-.contrib-q-row:hover { border-color: rgba(91, 154, 255, 0.35); }
-.contrib-q-row--urgent { border-color: rgba(239, 68, 68, 0.30); }
-.contrib-q-num {
-    font-family: 'IBM Plex Mono', monospace; font-size: 0.75rem;
-    color: var(--text-muted); min-width: 2.5rem;
+html.light-mode .admin-root .queue-row { border-color: rgba(0,51,127,0.08); }
+.admin-root .queue-row:hover {
+    border-color: rgba(91,154,255,0.35);
+    background: rgba(255,255,255,0.04);
+    transform: translateX(2px);
 }
-.contrib-q-body { flex: 1; min-width: 0; }
-.contrib-q-frage { font-size: 0.75rem; color: var(--text-primary); font-weight: 600; line-height: 1.35; }
-.contrib-q-sub { font-size: 0.625rem; color: var(--text-muted); margin-top: 0.125rem; }
-.contrib-q-rate {
-    font-family: 'IBM Plex Mono', monospace; font-weight: 700;
-    font-size: 0.8125rem; flex-shrink: 0;
+html.light-mode .admin-root .queue-row:hover { background: rgba(0,51,127,0.03); }
+.admin-root .queue-row--urgent { border-color: rgba(239,68,68,0.30); }
+.admin-root .queue-row--urgent:hover { border-color: rgba(239,68,68,0.50); }
+.admin-root .queue-count {
+    width: 40px; height: 40px; flex-shrink: 0; border-radius: 10px;
+    display: grid; place-items: center;
+    font-family: 'Figtree', sans-serif; font-weight: 800; font-size: 1.125rem;
+    letter-spacing: -0.02em;
+}
+.admin-root .queue-count--red   { background: rgba(239,68,68,0.14);  color: #ef4444; }
+.admin-root .queue-count--blue  { background: rgba(91,154,255,0.14); color: #5b9aff; }
+.admin-root .queue-count--gold  { background: rgba(251,191,36,0.14); color: #fbbf24; }
+.admin-root .queue-count--purp  { background: rgba(167,139,250,0.14); color: #a78bfa; }
+.admin-root .queue-count--green { background: rgba(34,197,94,0.14);  color: #22c55e; }
+html.light-mode .admin-root .queue-count--blue { color: var(--thw-blue); }
+.admin-root .queue-body { flex: 1; min-width: 0; }
+.admin-root .queue-title { font-size: 0.9375rem; font-weight: 700; color: var(--text-primary); margin-bottom: 0.125rem; }
+.admin-root .queue-sub { font-size: 0.75rem; color: var(--text-muted); }
+.admin-root .queue-arrow { color: var(--text-muted); font-size: 0.875rem; flex-shrink: 0; }
+
+/* Tiles */
+.admin-root .sr-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.625rem; margin-bottom: 1rem; }
+.admin-root .sr-tile {
+    padding: 0.75rem; border-radius: 0.625rem;
+    background: var(--glass-bg); border: 1px solid rgba(255,255,255,0.06);
+    text-align: center;
+}
+html.light-mode .admin-root .sr-tile { border-color: rgba(0,51,127,0.08); background: rgba(255,255,255,0.8); }
+.admin-root .sr-tile__val {
+    font-family: 'Figtree', sans-serif; font-weight: 800; font-size: 1.375rem;
+    line-height: 1; color: var(--text-primary); margin-bottom: 0.25rem;
+}
+.admin-root .sr-tile__val--gold  { color: #fbbf24; }
+.admin-root .sr-tile__val--green { color: #22c55e; }
+.admin-root .sr-tile__val--purp  { color: #a78bfa; }
+.admin-root .sr-tile__val--red   { color: #ef4444; }
+.admin-root .sr-tile__val--blue  { color: #5b9aff; }
+html.light-mode .admin-root .sr-tile__val--blue { color: var(--thw-blue); }
+.admin-root .sr-tile__lbl {
+    font-family: 'IBM Plex Mono', monospace; font-size: 0.625rem; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted);
 }
 
-/* Empty state */
-.contrib-empty {
-    text-align: center; padding: 1.5rem 0.5rem;
-    color: var(--text-muted); font-size: 0.875rem;
+/* Responsive */
+@media (max-width: 1100px) {
+    .admin-root .kpi-grid { grid-template-columns: repeat(3, 1fr); }
+    .admin-root .sys-pulse { grid-template-columns: repeat(2, 1fr); }
+    .admin-root .pulse-item + .pulse-item:nth-child(3) { border-left: 0; padding-left: 0; }
+    .admin-root .admin-grid, .admin-root .admin-grid--wide { grid-template-columns: 1fr; }
+    .admin-root .sr-stats { grid-template-columns: repeat(2, 1fr); }
 }
-.contrib-empty .bi {
-    display: block; font-size: 1.75rem; margin-bottom: 0.5rem;
-    color: var(--text-muted); opacity: 0.6;
+@media (max-width: 700px) {
+    .admin-root .kpi-grid { grid-template-columns: repeat(2, 1fr); }
+    .admin-root .sys-pulse { grid-template-columns: 1fr; }
+    .admin-root .pulse-item + .pulse-item {
+        border-left: 0; padding-left: 0;
+        border-top: 1px solid rgba(255,255,255,0.06); padding-top: 0.5rem;
+    }
+    html.light-mode .admin-root .pulse-item + .pulse-item { border-top-color: rgba(0,51,127,0.08); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .admin-root .pulse-dot--ok { animation: none; }
+    .admin-root .queue-row { transition: none; }
 }
 </style>
 @endpush
 
 @section('content')
 @php
-    $statusOrder = ['pending', 'approved', 'changed', 'rejected'];
+    $deltaClass = fn(string $dir) => match ($dir) {
+        'up' => 'kpi__delta--up',
+        'down' => 'kpi__delta--down',
+        default => 'kpi__delta--flat',
+    };
+    $deltaIcon = fn(string $dir) => match ($dir) {
+        'up' => 'bi-arrow-up',
+        'down' => 'bi-arrow-down',
+        default => '',
+    };
+
+    $statusLabels = [
+        'pending'  => 'Offen',
+        'approved' => 'Übernommen',
+        'changed'  => 'Mit Änderungen',
+        'rejected' => 'Abgelehnt',
+    ];
 @endphp
 
-<div class="dash-container">
-<div class="space-y-4">
+<div class="admin-root" id="admin-root">
 
     {{-- ── HEADER ───────────────────────────────── --}}
-    <header class="dashboard-header">
-        <h1 class="page-title">Contributor <span>Dashboard</span></h1>
-        <p class="page-subtitle">Fragen pflegen, Einreichungen sichten und Fehlermeldungen bearbeiten.</p>
-    </header>
-
-    {{-- ── STAT PILLS ───────────────────────────── --}}
-    <div class="stats-row">
-        <div class="stat-pill">
-            <span class="stat-pill-icon text-gold"><i class="bi bi-question-circle"></i></span>
-            <div>
-                <div class="stat-pill-value">{{ number_format($stats['fragen'], 0, ',', '.') }}</div>
-                <div class="stat-pill-label">Fragen</div>
-            </div>
+    <div class="admin-header">
+        <div>
+            <div class="admin-page-title__eyebrow">Contributor</div>
+            <h1 class="admin-page-title__h1">Dashboard</h1>
+            <p class="admin-page-title__sub">Fragen pflegen, Einreichungen sichten und Fehlermeldungen bearbeiten.</p>
         </div>
-        <div class="stat-pill">
-            <span class="stat-pill-icon text-gold"><i class="bi bi-plus-square"></i></span>
-            <div>
-                <div class="stat-pill-value">{{ number_format($stats['extraFragen'], 0, ',', '.') }}</div>
-                <div class="stat-pill-label">Zusatz-Fragen</div>
-            </div>
-        </div>
-        <div class="stat-pill">
-            <span class="stat-pill-icon text-gold"><i class="bi bi-mortarboard"></i></span>
-            <div>
-                <div class="stat-pill-value">{{ number_format($stats['lehrgaenge'], 0, ',', '.') }}</div>
-                <div class="stat-pill-label">Lehrgänge</div>
-            </div>
-        </div>
-        <div class="stat-pill">
-            <span class="stat-pill-icon text-gold"><i class="bi bi-pencil-square"></i></span>
-            <div>
-                <div class="stat-pill-value">{{ number_format($stats['entwuerfe'], 0, ',', '.') }}</div>
-                <div class="stat-pill-label">Entwürfe</div>
-            </div>
-        </div>
-        <div class="stat-pill">
-            <span class="stat-pill-icon text-gold"><i class="bi bi-inbox"></i></span>
-            <div>
-                <div class="stat-pill-value">{{ number_format($submissionStats['pending'], 0, ',', '.') }}</div>
-                <div class="stat-pill-label">Offene Vorschläge</div>
-            </div>
+        <div class="admin-header__right">
+            <button class="icon-btn-outline" id="refresh-btn" type="button" title="Aktualisieren">
+                <i class="bi bi-arrow-clockwise"></i> Aktualisieren
+            </button>
         </div>
     </div>
 
-    {{-- ── SECTION: HANDLUNGSBEDARF ─────────────── --}}
-    <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start);">
-        <h2 class="section-title">Handlungsbedarf</h2>
+    {{-- ── STATUS BAR ──────────────────────────── --}}
+    <div class="sys-pulse" role="status" aria-label="Status-Übersicht">
+        @foreach($statusBar as $item)
+            @php $href = $item['link'] ?? null; @endphp
+            @if($href)
+                <a class="pulse-item pulse-item--link" href="{{ $href }}" title="Details öffnen">
+                    <span class="pulse-dot pulse-dot--{{ $item['status'] }}"></span>
+                    <div class="pulse-meta">
+                        <div class="pulse-label">{{ $item['label'] }}</div>
+                        <div class="pulse-value">{{ $item['value'] }}</div>
+                        <div class="pulse-sub">{{ $item['sub'] }}</div>
+                    </div>
+                    <i class="bi bi-chevron-right pulse-chevron" aria-hidden="true"></i>
+                </a>
+            @else
+                <div class="pulse-item">
+                    <span class="pulse-dot pulse-dot--{{ $item['status'] }}"></span>
+                    <div class="pulse-meta">
+                        <div class="pulse-label">{{ $item['label'] }}</div>
+                        <div class="pulse-value">{{ $item['value'] }}</div>
+                        <div class="pulse-sub">{{ $item['sub'] }}</div>
+                    </div>
+                </div>
+            @endif
+        @endforeach
     </div>
 
-    <div class="bento-grid">
-
-        {{-- Priority Queue (2 von 3 Spalten) --}}
-        <div class="glass-gold bento-2of3">
-            <div class="contrib-card-h">
-                <span class="contrib-section-label">Offene Aufgaben</span>
-                @php $totalQueue = array_sum(array_column($handlungsbedarf, 'count')); @endphp
-                @if($totalQueue > 0)
-                    <span class="contrib-section-label" style="color: #ef4444;">
-                        {{ $totalQueue }} offen
-                    </span>
-                @else
-                    <span class="contrib-section-label" style="color: #22c55e;">Alles erledigt</span>
-                @endif
+    {{-- ── KPI GRID ─────────────────────────────── --}}
+    <div class="kpi-grid">
+        @foreach($kpis as $key => $kpi)
+            @php
+                $valueColorClass = match($kpi['color'] ?? null) {
+                    'blue' => 'kpi__value--blue',
+                    'ok'   => 'kpi__value--ok',
+                    default => '',
+                };
+            @endphp
+            <div class="kpi">
+                <div class="kpi__label">{{ $kpi['label'] }}</div>
+                <div class="kpi__value {{ $valueColorClass }}">{{ $kpi['value'] }}</div>
+                <span class="kpi__delta {{ $deltaClass($kpi['delta']['direction']) }}">
+                    @if($deltaIcon($kpi['delta']['direction']))
+                        <i class="bi {{ $deltaIcon($kpi['delta']['direction']) }}"></i>
+                    @endif
+                    {{ $kpi['delta']['text'] }}
+                </span>
+                <canvas class="kpi__spark" data-spark="{{ $key }}" data-points="{{ json_encode($kpi['spark']) }}"></canvas>
             </div>
-
-            <div style="display: flex; flex-direction: column; gap: 0.5rem;">
-                @forelse($handlungsbedarf as $row)
-                    <a class="contrib-queue-row {{ $row['urgent'] ? 'contrib-queue-row--urgent' : '' }}"
-                       href="{{ $row['link'] }}">
-                        <div class="contrib-queue-count contrib-queue-count--{{ $row['variant'] }}">{{ $row['count'] }}</div>
-                        <div class="contrib-queue-body">
-                            <div class="contrib-queue-title">{{ $row['title'] }}</div>
-                            <div class="contrib-queue-sub">{{ $row['sub'] }}</div>
-                        </div>
-                        <i class="bi bi-chevron-right contrib-queue-arrow"></i>
-                    </a>
-                @empty
-                    <div class="contrib-empty">
-                        <i class="bi bi-check-circle"></i>
-                        Keine offenen Aufgaben
-                    </div>
-                @endforelse
-            </div>
-        </div>
-
-        {{-- Quick Links (Sidebar) --}}
-        <div class="glass-tl bento-third">
-            <div class="contrib-card-h">
-                <span class="contrib-section-label">Schnellzugriff</span>
-            </div>
-
-            <div class="contrib-quick-list">
-                <a href="{{ route('admin.questions.index') }}" class="contrib-quick-link">
-                    <i class="bi bi-question-circle"></i>
-                    <div>
-                        <div class="contrib-quick-link__title">Fragen pflegen</div>
-                        <div class="contrib-quick-link__sub">Globaler Fragenpool</div>
-                    </div>
-                    <i class="bi bi-chevron-right"></i>
-                </a>
-                <a href="{{ route('admin.extra-questions.index') }}" class="contrib-quick-link">
-                    <i class="bi bi-plus-square"></i>
-                    <div>
-                        <div class="contrib-quick-link__title">Zusatz-Fragen</div>
-                        <div class="contrib-quick-link__sub">Bearbeiten</div>
-                    </div>
-                    <i class="bi bi-chevron-right"></i>
-                </a>
-                <a href="{{ route('admin.lehrgaenge.index') }}" class="contrib-quick-link">
-                    <i class="bi bi-mortarboard"></i>
-                    <div>
-                        <div class="contrib-quick-link__title">Lehrgänge</div>
-                        <div class="contrib-quick-link__sub">Fragen je Lehrgang</div>
-                    </div>
-                    <i class="bi bi-chevron-right"></i>
-                </a>
-                <a href="{{ route('admin.issues.index') }}" class="contrib-quick-link">
-                    <i class="bi bi-bug"></i>
-                    <div>
-                        <div class="contrib-quick-link__title">Fehlermeldungen</div>
-                        <div class="contrib-quick-link__sub">Issues bearbeiten</div>
-                    </div>
-                    <i class="bi bi-chevron-right"></i>
-                </a>
-            </div>
-        </div>
+        @endforeach
     </div>
 
-    {{-- ── SECTION: EINGEREICHTE ZUSATZ-FRAGEN ─── --}}
-    <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start);">
-        <h2 class="section-title">Eingereichte Zusatz-Fragen</h2>
-    </div>
-
-    <div class="bento-grid">
-
-        {{-- Status Übersicht --}}
-        <div class="glass-blue bento-third">
-            <div class="contrib-card-h">
-                <span class="contrib-section-label">Status</span>
-            </div>
-            <div style="display: flex; flex-direction: column; gap: 0.625rem;">
-                <div style="display: flex; align-items: baseline; justify-content: space-between;">
-                    <span style="font-size: 0.8125rem; color: var(--text-secondary);">Offen</span>
-                    <span style="font-family: 'Figtree', sans-serif; font-weight: 800; font-size: 1.25rem; color: #5b9aff;">
-                        {{ $submissionStats['pending'] }}
-                    </span>
-                </div>
-                <div style="display: flex; align-items: baseline; justify-content: space-between;">
-                    <span style="font-size: 0.8125rem; color: var(--text-secondary);">Übernommen</span>
-                    <span style="font-family: 'Figtree', sans-serif; font-weight: 800; font-size: 1.25rem; color: #22c55e;">
-                        {{ $submissionStats['approved'] + $submissionStats['changed'] }}
-                    </span>
-                </div>
-                <div style="display: flex; align-items: baseline; justify-content: space-between;">
-                    <span style="font-size: 0.8125rem; color: var(--text-secondary);">Abgelehnt</span>
-                    <span style="font-family: 'Figtree', sans-serif; font-weight: 800; font-size: 1.25rem; color: #ef4444;">
-                        {{ $submissionStats['rejected'] }}
-                    </span>
-                </div>
-                <div style="margin-top: 0.5rem; padding-top: 0.625rem; border-top: 1px solid rgba(255,255,255,0.08);">
-                    <a href="{{ route('admin.extra-question-submissions.index') }}" class="contrib-card-h-link">
-                        Alle Einreichungen →
-                    </a>
-                </div>
-            </div>
-        </div>
+    {{-- ── ROW 1: ZULETZT EINGEREICHT + HANDLUNGSBEDARF ─── --}}
+    <div class="admin-grid admin-grid--wide">
 
         {{-- Recent Submissions --}}
-        <div class="glass-tl bento-2of3">
-            <div class="contrib-card-h">
-                <span class="contrib-section-label">Zuletzt eingereicht</span>
-                <a href="{{ route('admin.extra-question-submissions.index', ['status' => 'pending']) }}" class="contrib-card-h-link">
-                    Offene →
-                </a>
+        <div class="card">
+            <div class="card-h">
+                <span class="section-label">Zuletzt eingereichte Zusatz-Fragen</span>
+                <a href="{{ route('admin.extra-question-submissions.index') }}" class="card-h-link">Alle →</a>
             </div>
-
-            <div>
+            <div class="feed">
                 @forelse($recentSubmissions as $s)
-                    <a href="{{ route('admin.extra-question-submissions.show', $s['id']) }}" class="contrib-sub-row">
-                        <div class="contrib-sub-body">
-                            <div class="contrib-sub-frage">{{ $s['frage'] }}</div>
-                            <div class="contrib-sub-meta">
-                                {{ $s['user_name'] }} · {{ $s['typ'] }} · LA {{ $s['lernabschnitt'] }} · vor {{ $s['created_human'] }}
+                    <a href="{{ route('admin.extra-question-submissions.show', $s['id']) }}" class="feed-item">
+                        <div class="feed-icon feed-icon--{{ $s['status'] === 'pending' ? 'blue' : ($s['status'] === 'approved' ? 'green' : ($s['status'] === 'changed' ? 'gold' : 'red')) }}">
+                            <i class="bi bi-inbox"></i>
+                        </div>
+                        <div class="feed-body">
+                            <div class="feed-text">
+                                <strong>{{ \Illuminate\Support\Str::limit($s['frage'], 80) }}</strong>
+                                <span class="muted"> · {{ $s['typ'] }} · LA {{ $s['lernabschnitt'] }}</span>
+                            </div>
+                            <div class="feed-meta">
+                                <span class="feed-time">vor {{ $s['created_human'] }}</span>
+                                <span class="feed-tag feed-tag--{{ $s['status'] }}">{{ $s['status_label'] }}</span>
+                                <span class="feed-time muted">{{ $s['user_name'] }}</span>
                             </div>
                         </div>
-                        <span class="contrib-status contrib-status--{{ $s['status'] }}">{{ $s['status_label'] }}</span>
                     </a>
                 @empty
-                    <div class="contrib-empty">
-                        <i class="bi bi-inbox"></i>
+                    <div style="text-align:center;padding:2rem;color:var(--text-muted);font-size:0.875rem;">
                         Noch keine Einreichungen
                     </div>
                 @endforelse
             </div>
         </div>
 
-    </div>
-
-    {{-- ── SECTION: FRAGEN-QUALITÄT ─────────────── --}}
-    <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start);">
-        <h2 class="section-title">Fragen-Qualität · letzte 30 Tage</h2>
-    </div>
-
-    <div class="bento-grid">
-
-        {{-- Top falsch --}}
-        <div class="glass-cyan bento-half">
-            <div class="contrib-card-h">
-                <span class="contrib-section-label">
-                    <i class="bi bi-x-circle-fill" style="color: #ef4444; margin-right: 0.25rem;"></i>
-                    Top 3 · am häufigsten falsch
-                </span>
-            </div>
-            @forelse($topFalsch as $q)
-                @php
-                    $rateColor = $q['wrong_rate'] >= 80 ? '#ef4444' : ($q['wrong_rate'] >= 60 ? '#f59e0b' : '#fbbf24');
-                    $rowUrgent = $q['wrong_rate'] >= 70;
-                @endphp
-                <a href="{{ route('admin.questions.edit', $q['id']) }}"
-                   class="contrib-q-row {{ $rowUrgent ? 'contrib-q-row--urgent' : '' }}">
-                    <div class="contrib-q-num">#{{ $q['nummer'] ?? $q['id'] }}</div>
-                    <div class="contrib-q-body">
-                        <div class="contrib-q-frage">{{ $q['frage'] }}</div>
-                        <div class="contrib-q-sub">
-                            {{ $q['lernabschnitt'] ? 'Abschnitt ' . $q['lernabschnitt'] . ' · ' : '' }}{{ $q['attempts'] }}×
-                        </div>
-                    </div>
-                    <div class="contrib-q-rate" style="color: {{ $rateColor }};">
-                        {{ number_format($q['wrong_rate'], 0, ',', '.') }} %
-                    </div>
-                </a>
-            @empty
-                <div class="contrib-empty">
-                    Noch nicht genug Daten
+        {{-- Handlungsbedarf --}}
+        <div class="card">
+            <div class="card-h">
+                <span class="section-label">Handlungsbedarf</span>
+                <div class="card-h-actions">
+                    @php $totalQueue = array_sum(array_column($handlungsbedarf, 'count')); @endphp
+                    @if($totalQueue > 0)
+                        <span class="feed-tag" style="color:#ef4444;border-color:rgba(239,68,68,0.3);background:rgba(239,68,68,0.08);">
+                            {{ $totalQueue }} offen
+                        </span>
+                    @else
+                        <span class="feed-tag" style="color:#22c55e;border-color:rgba(34,197,94,0.3);background:rgba(34,197,94,0.08);">Alles erledigt</span>
+                    @endif
                 </div>
-            @endforelse
+            </div>
+            <div class="queue-list">
+                @forelse($handlungsbedarf as $row)
+                    <a class="queue-row {{ $row['urgent'] ? 'queue-row--urgent' : '' }}" href="{{ $row['link'] }}">
+                        <div class="queue-count queue-count--{{ $row['variant'] }}">{{ $row['count'] }}</div>
+                        <div class="queue-body">
+                            <div class="queue-title">{{ $row['title'] }}</div>
+                            <div class="queue-sub">{{ $row['sub'] }}</div>
+                        </div>
+                        <i class="bi bi-chevron-right queue-arrow"></i>
+                    </a>
+                @empty
+                    <div style="text-align:center;padding:1.5rem;color:var(--text-muted);font-size:0.875rem;">
+                        Keine offenen Aufgaben
+                    </div>
+                @endforelse
+            </div>
+        </div>
+    </div>
+
+    {{-- ── ROW 2: EINREICHUNGS-STATUS + AKTUELLE FEHLERMELDUNGEN ── --}}
+    <div class="admin-grid">
+
+        {{-- Einreichungs-Status --}}
+        <div class="card">
+            <div class="card-h">
+                <span class="section-label">Einreichungs-Status</span>
+                <a href="{{ route('admin.extra-question-submissions.index') }}" class="card-h-link">Verwalten →</a>
+            </div>
+
+            <div class="sr-stats">
+                <div class="sr-tile">
+                    <div class="sr-tile__val sr-tile__val--blue">{{ $submissionStats['pending'] }}</div>
+                    <div class="sr-tile__lbl">Offen</div>
+                </div>
+                <div class="sr-tile">
+                    <div class="sr-tile__val sr-tile__val--green">{{ $submissionStats['approved'] }}</div>
+                    <div class="sr-tile__lbl">Übernommen</div>
+                </div>
+                <div class="sr-tile">
+                    <div class="sr-tile__val sr-tile__val--gold">{{ $submissionStats['changed'] }}</div>
+                    <div class="sr-tile__lbl">Geändert</div>
+                </div>
+                <div class="sr-tile">
+                    <div class="sr-tile__val sr-tile__val--red">{{ $submissionStats['rejected'] }}</div>
+                    <div class="sr-tile__lbl">Abgelehnt</div>
+                </div>
+            </div>
+
+            @php
+                $totalSubs = max($submissionStats['total'], 1);
+                $pctPending  = round(($submissionStats['pending'] / $totalSubs) * 100);
+                $pctApproved = round(($submissionStats['approved'] / $totalSubs) * 100);
+                $pctChanged  = round(($submissionStats['changed'] / $totalSubs) * 100);
+                $pctRejected = round(($submissionStats['rejected'] / $totalSubs) * 100);
+            @endphp
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.375rem;">
+                <span class="section-label" style="font-size:0.625rem;">Verteilung</span>
+                <span style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;color:var(--text-muted);">{{ number_format($submissionStats['total'], 0, ',', '.') }} Einreichungen</span>
+            </div>
+            <div style="display:flex;height:12px;border-radius:999px;overflow:hidden;margin-bottom:0.625rem;background:rgba(255,255,255,0.06);">
+                <div style="width:{{ $pctPending }}%;background:#5b9aff;"></div>
+                <div style="width:{{ $pctApproved }}%;background:#22c55e;"></div>
+                <div style="width:{{ $pctChanged }}%;background:#fbbf24;"></div>
+                <div style="width:{{ $pctRejected }}%;background:#ef4444;"></div>
+            </div>
+            <div style="display:flex;flex-wrap:wrap;gap:0.875rem;font-size:0.6875rem;color:var(--text-muted);">
+                <div style="display:inline-flex;align-items:center;gap:0.35rem;"><span style="width:8px;height:8px;border-radius:2px;background:#5b9aff;"></span>Offen · {{ $pctPending }}%</div>
+                <div style="display:inline-flex;align-items:center;gap:0.35rem;"><span style="width:8px;height:8px;border-radius:2px;background:#22c55e;"></span>Übernommen · {{ $pctApproved }}%</div>
+                <div style="display:inline-flex;align-items:center;gap:0.35rem;"><span style="width:8px;height:8px;border-radius:2px;background:#fbbf24;"></span>Geändert · {{ $pctChanged }}%</div>
+                <div style="display:inline-flex;align-items:center;gap:0.35rem;"><span style="width:8px;height:8px;border-radius:2px;background:#ef4444;"></span>Abgelehnt · {{ $pctRejected }}%</div>
+            </div>
         </div>
 
-        {{-- Top richtig --}}
-        <div class="glass-green bento-half">
-            <div class="contrib-card-h">
-                <span class="contrib-section-label">
-                    <i class="bi bi-check-circle-fill" style="color: #22c55e; margin-right: 0.25rem;"></i>
-                    Top 3 · am häufigsten richtig
-                </span>
+        {{-- Aktuelle Fehlermeldungen --}}
+        <div class="card">
+            <div class="card-h">
+                <span class="section-label">Aktuelle Fehlermeldungen</span>
+                <a href="{{ route('admin.issues.index') }}" class="card-h-link">Alle →</a>
             </div>
-            @forelse($topRichtig as $q)
-                <a href="{{ route('admin.questions.edit', $q['id']) }}" class="contrib-q-row">
-                    <div class="contrib-q-num">#{{ $q['nummer'] ?? $q['id'] }}</div>
-                    <div class="contrib-q-body">
-                        <div class="contrib-q-frage">{{ $q['frage'] }}</div>
-                        <div class="contrib-q-sub">
-                            {{ $q['lernabschnitt'] ? 'Abschnitt ' . $q['lernabschnitt'] . ' · ' : '' }}{{ $q['attempts'] }}×
+            <div class="feed">
+                @forelse($recentIssues as $i)
+                    <a href="{{ route('admin.issues.index') }}" class="feed-item">
+                        <div class="feed-icon feed-icon--red">
+                            <i class="bi bi-bug-fill"></i>
                         </div>
-                    </div>
-                    <div class="contrib-q-rate" style="color: #22c55e;">
-                        {{ number_format($q['correct_rate'], 0, ',', '.') }} %
-                    </div>
-                </a>
-            @empty
-                <div class="contrib-empty">
-                    Noch nicht genug Daten
-                </div>
-            @endforelse
-        </div>
-
-    </div>
-
-    {{-- ── SECTION: AKTUELLE FEHLERMELDUNGEN ──── --}}
-    @if(count($recentIssues) > 0)
-    <div class="section-header" style="padding-left: 1rem; border-left: 3px solid var(--gold-start);">
-        <h2 class="section-title">Aktuelle Fehlermeldungen</h2>
-    </div>
-
-    <div class="bento-grid">
-        <div class="glass-tl bento-wide">
-            <div class="contrib-card-h">
-                <span class="contrib-section-label">Offen · zur Sichtung</span>
-                <a href="{{ route('admin.issues.index') }}" class="contrib-card-h-link">Alle →</a>
-            </div>
-
-            <div>
-                @foreach($recentIssues as $i)
-                    <a href="{{ route('admin.issues.index') }}" class="contrib-sub-row">
-                        <div class="contrib-sub-body">
-                            <div class="contrib-sub-frage">
-                                <i class="bi bi-bug-fill" style="color: #ef4444; margin-right: 0.25rem;"></i>
-                                {{ $i['title'] }}
+                        <div class="feed-body">
+                            <div class="feed-text">
+                                <strong>{{ $i['title'] }}</strong>
                                 @if(!empty($i['frage']))
-                                    <span style="color: var(--text-muted); font-weight: 400;">– {{ $i['frage'] }}</span>
+                                    <span class="muted"> – {{ $i['frage'] }}</span>
                                 @endif
                             </div>
-                            <div class="contrib-sub-meta">
-                                {{ $i['kind'] === 'lehrgang' ? 'Lehrgang' : 'Globale Frage' }} · vor {{ $i['created_human'] }}
+                            <div class="feed-meta">
+                                <span class="feed-time">vor {{ $i['created_human'] }}</span>
+                                <span class="feed-tag">{{ $i['kind'] === 'lehrgang' ? 'Lehrgang' : 'Frage' }}</span>
                             </div>
                         </div>
-                        <i class="bi bi-chevron-right" style="color: var(--text-muted); font-size: 0.875rem;"></i>
                     </a>
-                @endforeach
+                @empty
+                    <div style="text-align:center;padding:2rem;color:var(--text-muted);font-size:0.875rem;">
+                        Keine offenen Fehlermeldungen
+                    </div>
+                @endforelse
             </div>
         </div>
     </div>
-    @endif
+
+    {{-- ── ROW 3: FRAGEN-QUALITÄT ─── --}}
+    <div class="admin-grid">
+        <div class="card" style="grid-column: span 2;">
+            <div class="card-h">
+                <span class="section-label">Fragen-Qualität · letzte 30 Tage</span>
+                <a href="{{ route('admin.questions.index') }}" class="card-h-link">Fragen →</a>
+            </div>
+
+            <div style="margin-bottom: 1rem;">
+                <div style="display:flex;justify-content:space-between;align-items:baseline;gap:0.5rem;margin-bottom:0.625rem;flex-wrap:nowrap;">
+                    <div style="min-width: 0;">
+                        <span style="font-family:'Figtree',sans-serif;font-weight:800;font-size:1.5rem;color:#22c55e;line-height:1;">{{ number_format($fragenQualitaet['correct'], 0, ',', '.') }}</span>
+                        <span style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;color:var(--text-muted);margin-left:0.375rem;white-space:nowrap;">RICHTIG</span>
+                    </div>
+                    <div style="text-align:right;min-width:0;">
+                        <span style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;color:var(--text-muted);margin-right:0.375rem;white-space:nowrap;">FALSCH</span>
+                        <span style="font-family:'Figtree',sans-serif;font-weight:800;font-size:1.5rem;color:#ef4444;line-height:1;">{{ number_format($fragenQualitaet['wrong'], 0, ',', '.') }}</span>
+                    </div>
+                </div>
+                @php
+                    $sr = max($fragenQualitaet['totalAnswered'], 1);
+                    $correctPct = ($fragenQualitaet['correct'] / $sr) * 100;
+                    $wrongPct = 100 - $correctPct;
+                @endphp
+                <div style="display:flex;height:10px;border-radius:999px;overflow:hidden;background:rgba(255,255,255,0.06);margin-bottom:0.375rem;">
+                    <div style="width:{{ $correctPct }}%;background:#22c55e;"></div>
+                    <div style="width:{{ $wrongPct }}%;background:#ef4444;"></div>
+                </div>
+                <div style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;color:var(--text-muted);text-align:center;">
+                    {{ number_format($fragenQualitaet['successRate'], 1, ',', '.') }} % Erfolgsrate
+                </div>
+            </div>
+
+            <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:0.5rem;margin-bottom:1.25rem;">
+                <div class="sr-tile">
+                    <div class="sr-tile__val">{{ number_format($fragenQualitaet['totalFragen'], 0, ',', '.') }}</div>
+                    <div class="sr-tile__lbl">Fragen gesamt</div>
+                </div>
+                <div class="sr-tile">
+                    <div class="sr-tile__val sr-tile__val--purp">{{ number_format($fragenQualitaet['totalAnswered'], 0, ',', '.') }}</div>
+                    <div class="sr-tile__lbl">Antworten (30 T)</div>
+                </div>
+                <div class="sr-tile">
+                    <div class="sr-tile__val" style="color:#fbbf24;">{{ $fragenQualitaet['entwuerfe'] }}</div>
+                    <div class="sr-tile__lbl">Entwürfe</div>
+                </div>
+            </div>
+
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;">
+                <div>
+                    <div style="display:flex;align-items:center;gap:0.375rem;margin-bottom:0.625rem;">
+                        <i class="bi bi-check-circle-fill" style="color:#22c55e;font-size:0.8125rem;"></i>
+                        <span class="section-label" style="font-size:0.625rem;">Top 3 · am häufigsten richtig</span>
+                    </div>
+                    @forelse($fragenQualitaet['topRichtig'] as $q)
+                        <a href="{{ route('admin.questions.edit', $q['id']) }}" class="queue-row" style="padding:0.5rem 0.625rem;margin-bottom:0.375rem;">
+                            <div style="font-family:'IBM Plex Mono',monospace;font-size:0.75rem;color:var(--text-muted);min-width:2.5rem;">#{{ $q['nummer'] ?? $q['id'] }}</div>
+                            <div class="queue-body">
+                                <div style="font-size:0.75rem;color:var(--text-primary);font-weight:600;">{{ $q['frage'] }}</div>
+                                <div style="font-size:0.625rem;color:var(--text-muted);">{{ $q['lernabschnitt'] ? 'Abschnitt ' . $q['lernabschnitt'] . ' · ' : '' }}{{ $q['attempts'] }}×</div>
+                            </div>
+                            <div style="font-family:'IBM Plex Mono',monospace;font-weight:700;color:#22c55e;font-size:0.8125rem;">{{ number_format($q['correct_rate'], 0, ',', '.') }} %</div>
+                        </a>
+                    @empty
+                        <div style="color:var(--text-muted);font-size:0.75rem;padding:0.75rem 0;">Noch nicht genug Daten</div>
+                    @endforelse
+                </div>
+
+                <div>
+                    <div style="display:flex;align-items:center;gap:0.375rem;margin-bottom:0.625rem;">
+                        <i class="bi bi-x-circle-fill" style="color:#ef4444;font-size:0.8125rem;"></i>
+                        <span class="section-label" style="font-size:0.625rem;">Top 3 · am häufigsten falsch</span>
+                    </div>
+                    @forelse($fragenQualitaet['topFalsch'] as $q)
+                        @php
+                            $rateColor = $q['wrong_rate'] >= 80 ? '#ef4444' : ($q['wrong_rate'] >= 60 ? '#f59e0b' : '#fbbf24');
+                            $rowClass  = $q['wrong_rate'] >= 70 ? 'queue-row queue-row--urgent' : 'queue-row';
+                        @endphp
+                        <a href="{{ route('admin.questions.edit', $q['id']) }}" class="{{ $rowClass }}" style="padding:0.5rem 0.625rem;margin-bottom:0.375rem;">
+                            <div style="font-family:'IBM Plex Mono',monospace;font-size:0.75rem;color:var(--text-muted);min-width:2.5rem;">#{{ $q['nummer'] ?? $q['id'] }}</div>
+                            <div class="queue-body">
+                                <div style="font-size:0.75rem;color:var(--text-primary);font-weight:600;">{{ $q['frage'] }}</div>
+                                <div style="font-size:0.625rem;color:var(--text-muted);">{{ $q['lernabschnitt'] ? 'Abschnitt ' . $q['lernabschnitt'] . ' · ' : '' }}{{ $q['attempts'] }}×</div>
+                            </div>
+                            <div style="font-family:'IBM Plex Mono',monospace;font-weight:700;color:{{ $rateColor }};font-size:0.8125rem;">{{ number_format($q['wrong_rate'], 0, ',', '.') }} %</div>
+                        </a>
+                    @empty
+                        <div style="color:var(--text-muted);font-size:0.75rem;padding:0.75rem 0;">Noch nicht genug Daten</div>
+                    @endforelse
+                </div>
+            </div>
+        </div>
+    </div>
 
 </div>
-</div>
 @endsection
+
+@push('scripts')
+<script>
+(function() {
+    const root = document.getElementById('admin-root');
+    if (!root) return;
+
+    // ------- Sparklines -------
+    function drawSpark(canvas) {
+        const raw = canvas.getAttribute('data-points');
+        if (!raw) return;
+        let data;
+        try { data = JSON.parse(raw); } catch (e) { return; }
+        if (!Array.isArray(data) || data.length < 2) return;
+
+        const key = canvas.getAttribute('data-spark');
+        const colors = {
+            fragen: '#5b9aff',
+            extra: '#22c55e',
+            lehrgaenge: '#a78bfa',
+            entwuerfe: '#fbbf24',
+            vorschlaege: '#5b9aff',
+        };
+        const color = colors[key] || '#5b9aff';
+
+        const dpr = window.devicePixelRatio || 1;
+        const w = canvas.offsetWidth, h = canvas.offsetHeight;
+        if (w === 0 || h === 0) return;
+        canvas.width = w * dpr; canvas.height = h * dpr;
+        const ctx = canvas.getContext('2d');
+        ctx.scale(dpr, dpr);
+        ctx.clearRect(0, 0, w, h);
+
+        const min = Math.min(...data), max = Math.max(...data);
+        const range = (max - min) || 1;
+        const stepX = w / (data.length - 1);
+        const y = i => h - 4 - ((data[i] - min) / range) * (h - 8);
+        const pts = data.map((_, i) => [i * stepX, y(i)]);
+
+        function smoothPath(ctx, points) {
+            if (points.length < 2) return;
+            ctx.moveTo(points[0][0], points[0][1]);
+            if (points.length === 2) { ctx.lineTo(points[1][0], points[1][1]); return; }
+            for (let i = 0; i < points.length - 1; i++) {
+                const p0 = points[i - 1] || points[i];
+                const p1 = points[i];
+                const p2 = points[i + 1];
+                const p3 = points[i + 2] || p2;
+                const cp1x = p1[0] + (p2[0] - p0[0]) / 6;
+                const cp1y = p1[1] + (p2[1] - p0[1]) / 6;
+                const cp2x = p2[0] - (p3[0] - p1[0]) / 6;
+                const cp2y = p2[1] - (p3[1] - p1[1]) / 6;
+                ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, p2[0], p2[1]);
+            }
+        }
+
+        ctx.beginPath();
+        ctx.moveTo(0, h);
+        ctx.lineTo(pts[0][0], pts[0][1]);
+        smoothPath(ctx, pts);
+        ctx.lineTo(w, h); ctx.closePath();
+        const grad = ctx.createLinearGradient(0, 0, 0, h);
+        grad.addColorStop(0, color + '55');
+        grad.addColorStop(1, color + '00');
+        ctx.fillStyle = grad; ctx.fill();
+
+        ctx.beginPath();
+        smoothPath(ctx, pts);
+        ctx.lineWidth = 1.75;
+        ctx.strokeStyle = color;
+        ctx.lineJoin = 'round';
+        ctx.lineCap = 'round';
+        ctx.stroke();
+    }
+
+    function renderSparks() {
+        root.querySelectorAll('.kpi__spark').forEach(drawSpark);
+    }
+
+    // ------- Refresh -------
+    document.getElementById('refresh-btn')?.addEventListener('click', () => {
+        window.location.reload();
+    });
+
+    // ------- Init -------
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', renderSparks);
+    } else {
+        renderSparks();
+    }
+    window.addEventListener('resize', () => {
+        requestAnimationFrame(renderSparks);
+    });
+})();
+</script>
+@endpush


### PR DESCRIPTION
- View komplett umgebaut: gleiche Klassen (.admin-root, .sys-pulse, .kpi-grid, .admin-grid, .card, .queue-list, .feed, .sr-tile) und identische CSS-Tokens wie das Admin-Dashboard
- Status-Bar oben (analog System-Puls): Fragen-Pool, Zusatz-Fragen, Lehrgänge, Fehlermeldungen mit Status-Dot (ok/warn/err) und Link
- KPI-Grid mit 5 Karten + animierten Sparklines (Trend letzte 14 Tage)
- Row 1: Zuletzt eingereichte Zusatz-Fragen (Feed) + Handlungsbedarf-Queue
- Row 2: Einreichungs-Status (sr-tiles + Verteilungs-Balken) + aktuelle Fehlermeldungen
- Row 3: Fragen-Qualität (Richtig/Falsch-Balken, sr-tiles, Top 3 richtig/falsch)
- Controller liefert dazu passende Daten: statusBar, kpis (mit spark-Arrays), handlungsbedarf, recentSubmissions, submissionStats, fragenQualitaet, recentIssues
- Sparkline-Renderer (Canvas) wie im Admin-Dashboard, inkl. Refresh-Button