### PR TITLE
✨ Jira-style activity feed for issue tracking

### DIFF
--- a/app/Http/Controllers/Admin/IssueController.php
+++ b/app/Http/Controllers/Admin/IssueController.php
@@ -4,7 +4,9 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\LehrgangQuestionIssue;
+use App\Models\LehrgangQuestionIssueReport;
 use App\Models\QuestionIssue;
+use App\Models\QuestionIssueReport;
 use Illuminate\Http\Request;
 
 class IssueController extends Controller
@@ -138,7 +140,7 @@ class IssueController extends Controller
     }
 
     /**
-     * Update Status und Admin Notes
+     * Update Status (loggt Statuswechsel als Aktivität)
      */
     public function update(Request $request, $id)
     {
@@ -146,19 +148,47 @@ class IssueController extends Controller
 
         $validated = $request->validate([
             'status' => 'required|in:open,in_review,resolved,rejected',
-            'admin_notes' => 'nullable|string|max:1000',
         ]);
 
-        if ($type === 'lehrgang') {
-            $issue = LehrgangQuestionIssue::findOrFail($id);
-        } else {
-            $issue = QuestionIssue::findOrFail($id);
+        $issue = $type === 'lehrgang'
+            ? LehrgangQuestionIssue::findOrFail($id)
+            : QuestionIssue::findOrFail($id);
+
+        $oldStatus = $issue->status;
+        $newStatus = $validated['status'];
+
+        if ($oldStatus !== $newStatus) {
+            $issue->update(['status' => $newStatus]);
+
+            $this->createActivity($issue, $type, 'status_change', null, [
+                'old' => $oldStatus,
+                'new' => $newStatus,
+            ]);
         }
 
-        $issue->update($validated);
+        return redirect()->route('admin.issues.show', ['issue' => $id, 'type' => $type])
+                       ->with('success', 'Status aktualisiert!');
+    }
+
+    /**
+     * Neuer Kommentar (Notiz) im Aktivitäts-Feed
+     */
+    public function storeComment(Request $request, $id)
+    {
+        $type = $request->get('type', 'lehrgang');
+
+        $validated = $request->validate([
+            'message' => 'required|string|max:2000',
+        ]);
+
+        $issue = $type === 'lehrgang'
+            ? LehrgangQuestionIssue::findOrFail($id)
+            : QuestionIssue::findOrFail($id);
+
+        $this->createActivity($issue, $type, 'note', $validated['message']);
 
         return redirect()->route('admin.issues.show', ['issue' => $id, 'type' => $type])
-                       ->with('success', 'Fehlermeldung aktualisiert!');
+                       ->with('success', 'Kommentar hinzugefügt!');
     }
 
     /**
@@ -176,5 +206,31 @@ class IssueController extends Controller
 
         return redirect()->route('admin.issues.index')
                        ->with('success', 'Fehlermeldung gelöscht.');
+    }
+
+    /**
+     * Erstellt einen Aktivitäts-Eintrag (Report, Notiz oder Status-Wechsel)
+     */
+    private function createActivity($issue, string $type, string $activityType, ?string $message, ?array $meta = null): void
+    {
+        $userId = auth()->id();
+
+        if ($type === 'lehrgang') {
+            LehrgangQuestionIssueReport::create([
+                'lehrgang_question_issue_id' => $issue->id,
+                'user_id' => $userId,
+                'type' => $activityType,
+                'message' => $message,
+                'meta' => $meta,
+            ]);
+        } else {
+            QuestionIssueReport::create([
+                'question_issue_id' => $issue->id,
+                'user_id' => $userId,
+                'type' => $activityType,
+                'message' => $message,
+                'meta' => $meta,
+            ]);
+        }
     }
 }

--- a/app/Models/LehrgangQuestionIssueReport.php
+++ b/app/Models/LehrgangQuestionIssueReport.php
@@ -13,12 +13,15 @@ class LehrgangQuestionIssueReport extends Model
     protected $fillable = [
         'lehrgang_question_issue_id',
         'user_id',
+        'type',
         'message',
+        'meta',
     ];
-    
+
     protected $casts = [
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
+        'meta' => 'array',
     ];
     
     // Relationships

--- a/app/Models/QuestionIssueReport.php
+++ b/app/Models/QuestionIssueReport.php
@@ -11,12 +11,15 @@ class QuestionIssueReport extends Model
     protected $fillable = [
         'question_issue_id',
         'user_id',
+        'type',
         'message',
+        'meta',
     ];
 
     protected $casts = [
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
+        'meta' => 'array',
     ];
 
     public function issue()

--- a/database/migrations/2026_05_13_000001_add_type_and_meta_to_issue_reports.php
+++ b/database/migrations/2026_05_13_000001_add_type_and_meta_to_issue_reports.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('lehrgang_question_issue_reports', function (Blueprint $table) {
+            $table->string('type', 20)->default('report')->after('user_id');
+            $table->json('meta')->nullable()->after('message');
+            $table->index('type', 'lehrgang_issue_reports_type_idx');
+        });
+
+        Schema::table('question_issue_reports', function (Blueprint $table) {
+            $table->string('type', 20)->default('report')->after('user_id');
+            $table->json('meta')->nullable()->after('message');
+            $table->index('type', 'question_issue_reports_type_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lehrgang_question_issue_reports', function (Blueprint $table) {
+            $table->dropIndex('lehrgang_issue_reports_type_idx');
+            $table->dropColumn(['type', 'meta']);
+        });
+
+        Schema::table('question_issue_reports', function (Blueprint $table) {
+            $table->dropIndex('question_issue_reports_type_idx');
+            $table->dropColumn(['type', 'meta']);
+        });
+    }
+};

--- a/resources/views/admin/issues/show.blade.php
+++ b/resources/views/admin/issues/show.blade.php
@@ -280,6 +280,104 @@ html.light-mode .iss-root .report__avatar { background: var(--thw-blue); }
 .iss-root .report__msg { font-size: 0.875rem; color: var(--text-secondary); line-height: 1.5; margin: 0; }
 .iss-root .report__msg--empty { font-style: italic; color: var(--text-muted); }
 
+/* Activity feed (Jira-style: report = note = status_change = comment) */
+.iss-root .activity-feed { display: flex; flex-direction: column; gap: 0.5rem; }
+.iss-root .activity {
+    display: flex; gap: 0.75rem;
+    padding: 0.75rem 0.875rem;
+    border-radius: 0.625rem;
+    background: rgba(255,255,255,0.02);
+    border: 1px solid rgba(255,255,255,0.05);
+}
+html.light-mode .iss-root .activity {
+    background: rgba(0,51,127,0.02); border-color: rgba(0,51,127,0.06);
+}
+.iss-root .activity--note {
+    background: rgba(251,191,36,0.06);
+    border-color: rgba(251,191,36,0.18);
+}
+.iss-root .activity--status {
+    background: rgba(91,154,255,0.05);
+    border-color: rgba(91,154,255,0.16);
+    align-items: center;
+}
+html.light-mode .iss-root .activity--status {
+    background: rgba(0,51,127,0.04); border-color: rgba(0,51,127,0.12);
+}
+.iss-root .activity__avatar {
+    width: 2rem; height: 2rem; flex-shrink: 0;
+    border-radius: 50%;
+    background: #5b9aff; color: #fff;
+    display: grid; place-items: center;
+    font-weight: 700; font-size: 0.8125rem;
+}
+html.light-mode .iss-root .activity__avatar { background: var(--thw-blue); }
+.iss-root .activity__avatar--note   { background: #fbbf24; color: #1a1a1a; }
+.iss-root .activity__avatar--status { background: rgba(91,154,255,0.18); color: #5b9aff; font-size: 0.9rem; }
+html.light-mode .iss-root .activity__avatar--status {
+    background: rgba(0,51,127,0.12); color: var(--thw-blue);
+}
+.iss-root .activity__body { flex: 1; min-width: 0; }
+.iss-root .activity__head {
+    display: flex; align-items: center; gap: 0.5rem;
+    margin-bottom: 0.25rem; flex-wrap: wrap;
+}
+.iss-root .activity__name {
+    font-weight: 700; font-size: 0.8125rem; color: var(--text-primary);
+}
+.iss-root .activity__badge {
+    display: inline-flex; align-items: center;
+    padding: 0.1rem 0.45rem; border-radius: 999px;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.5625rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.08em;
+    background: rgba(251,191,36,0.16); color: #fbbf24;
+}
+.iss-root .activity__badge--report {
+    background: rgba(91,154,255,0.16); color: #5b9aff;
+}
+html.light-mode .iss-root .activity__badge--report { color: var(--thw-blue); }
+.iss-root .activity__time {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.625rem; color: var(--text-muted);
+    margin-left: auto;
+}
+.iss-root .activity__msg {
+    font-size: 0.875rem; color: var(--text-secondary);
+    line-height: 1.5; margin: 0;
+    white-space: pre-wrap; word-break: break-word;
+}
+.iss-root .activity__msg--empty { font-style: italic; color: var(--text-muted); }
+.iss-root .activity__line {
+    font-size: 0.8125rem; color: var(--text-secondary);
+    margin: 0; line-height: 1.5;
+    display: flex; align-items: center; gap: 0.35rem; flex-wrap: wrap;
+}
+.iss-root .activity__line strong { color: var(--text-primary); font-weight: 700; }
+.iss-root .activity--status .activity__time { margin-left: 0; flex-basis: 100%; margin-top: 0.2rem; }
+
+/* Compose / new comment form */
+.iss-root .activity-compose {
+    display: flex; gap: 0.75rem;
+    margin-top: 1rem; padding-top: 1rem;
+    border-top: 1px solid rgba(255,255,255,0.06);
+}
+html.light-mode .iss-root .activity-compose { border-top-color: rgba(0,51,127,0.08); }
+.iss-root .activity-compose__avatar {
+    width: 2rem; height: 2rem; flex-shrink: 0;
+    border-radius: 50%;
+    background: #5b9aff; color: #fff;
+    display: grid; place-items: center;
+    font-weight: 700; font-size: 0.8125rem;
+}
+html.light-mode .iss-root .activity-compose__avatar { background: var(--thw-blue); }
+.iss-root .activity-compose__body { flex: 1; min-width: 0; }
+.iss-root .activity-compose__body .textarea { min-height: 72px; }
+.iss-root .activity-compose__actions {
+    display: flex; justify-content: flex-end;
+    margin-top: 0.5rem;
+}
+
 /* Alert */
 .iss-root .alert {
     display: flex; gap: 0.75rem; align-items: flex-start;
@@ -497,43 +595,117 @@ html.light-mode .iss-root .report__avatar { background: var(--thw-blue); }
 
             <div class="card">
                 <div class="card-h">
-                    <span class="section-label">Meldungen · {{ $issue->reports->count() ?: 1 }}</span>
+                    <span class="section-label">Aktivität</span>
                     <span class="chip chip--count">{{ $issue->report_count }}× gemeldet</span>
                 </div>
 
-                <div class="reports">
-                    @forelse($issue->reports as $report)
-                        <div class="report">
-                            <div class="report__avatar">{{ strtoupper(substr($report->user?->name ?? 'A', 0, 1)) }}</div>
-                            <div class="report__body">
-                                <div class="report__head">
-                                    <span class="report__name">{{ $report->user?->name ?? 'Anonym' }}</span>
-                                    <span class="report__time">{{ $report->created_at->format('d.m.Y H:i') }}</span>
+                @php
+                    // Status-Labels für Statuswechsel-Einträge
+                    $statusLabels = [
+                        'open'      => 'Offen',
+                        'in_review' => 'In Bearbeitung',
+                        'resolved'  => 'Gelöst',
+                        'rejected'  => 'Abgelehnt',
+                    ];
+
+                    // Aktivitäten = alle reports + synthetischer Initial-Eintrag
+                    // (falls Issue keine 'report'-Zeilen hat, aber latest_message existiert)
+                    $activities = $issue->reports->sortBy('created_at')->values();
+                    $hasReportRow = $activities->contains(fn ($a) => ($a->type ?? 'report') === 'report');
+                    if (! $hasReportRow && $issue->reportedByUser) {
+                        $activities = collect([(object) [
+                            '_synthetic' => true,
+                            'type' => 'report',
+                            'message' => $issue->latest_message,
+                            'user' => $issue->reportedByUser,
+                            'created_at' => $issue->created_at,
+                            'meta' => null,
+                        ]])->merge($activities)->values();
+                    }
+                @endphp
+
+                <div class="activity-feed">
+                    @foreach($activities as $act)
+                        @php
+                            $actType = $act->type ?? 'report';
+                            $actUserName = $act->user?->name ?? 'Anonym';
+                            $actInitial = strtoupper(substr($actUserName, 0, 1));
+                        @endphp
+
+                        @if($actType === 'status_change')
+                            <div class="activity activity--status">
+                                <div class="activity__avatar activity__avatar--status">
+                                    <i class="bi bi-arrow-left-right"></i>
                                 </div>
-                                @if($report->message)
-                                    <p class="report__msg">{{ $report->message }}</p>
-                                @else
-                                    <p class="report__msg report__msg--empty">Keine Nachricht</p>
-                                @endif
-                            </div>
-                        </div>
-                    @empty
-                        <div class="report">
-                            <div class="report__avatar">{{ strtoupper(substr($issue->reportedByUser?->name ?? 'A', 0, 1)) }}</div>
-                            <div class="report__body">
-                                <div class="report__head">
-                                    <span class="report__name">{{ $issue->reportedByUser?->name ?? 'Anonym' }}</span>
-                                    <span class="report__time">{{ $issue->updated_at?->format('d.m.Y H:i') }}</span>
+                                <div class="activity__body">
+                                    <p class="activity__line">
+                                        <strong>{{ $actUserName }}</strong>
+                                        änderte Status
+                                        @php
+                                            $old = $act->meta['old'] ?? null;
+                                            $new = $act->meta['new'] ?? null;
+                                        @endphp
+                                        @if($old)
+                                            von <span class="chip chip--{{ $old }}">{{ $statusLabels[$old] ?? $old }}</span>
+                                        @endif
+                                        @if($new)
+                                            auf <span class="chip chip--{{ $new }}">{{ $statusLabels[$new] ?? $new }}</span>
+                                        @endif
+                                    </p>
+                                    <span class="activity__time">{{ $act->created_at->format('d.m.Y H:i') }}</span>
                                 </div>
-                                @if($issue->latest_message)
-                                    <p class="report__msg">{{ $issue->latest_message }}</p>
-                                @else
-                                    <p class="report__msg report__msg--empty">Keine Nachricht</p>
-                                @endif
                             </div>
-                        </div>
-                    @endforelse
+                        @elseif($actType === 'note')
+                            <div class="activity activity--note">
+                                <div class="activity__avatar activity__avatar--note">{{ $actInitial }}</div>
+                                <div class="activity__body">
+                                    <div class="activity__head">
+                                        <span class="activity__name">{{ $actUserName }}</span>
+                                        <span class="activity__badge">Notiz</span>
+                                        <span class="activity__time">{{ $act->created_at->format('d.m.Y H:i') }}</span>
+                                    </div>
+                                    <p class="activity__msg">{{ $act->message }}</p>
+                                </div>
+                            </div>
+                        @else
+                            <div class="activity activity--report">
+                                <div class="activity__avatar">{{ $actInitial }}</div>
+                                <div class="activity__body">
+                                    <div class="activity__head">
+                                        <span class="activity__name">{{ $actUserName }}</span>
+                                        <span class="activity__badge activity__badge--report">Meldung</span>
+                                        <span class="activity__time">{{ $act->created_at->format('d.m.Y H:i') }}</span>
+                                    </div>
+                                    @if($act->message)
+                                        <p class="activity__msg">{{ $act->message }}</p>
+                                    @else
+                                        <p class="activity__msg activity__msg--empty">Keine Nachricht</p>
+                                    @endif
+                                </div>
+                            </div>
+                        @endif
+                    @endforeach
                 </div>
+
+                {{-- Kommentar-Eingabe (Jira-Style: alles ist ein Kommentar) --}}
+                <form method="POST"
+                      action="{{ route('admin.issues.comments.store', ['issue' => $issue->id, 'type' => $type]) }}"
+                      class="activity-compose">
+                    @csrf
+                    <div class="activity-compose__avatar">{{ strtoupper(substr(auth()->user()->name ?? 'A', 0, 1)) }}</div>
+                    <div class="activity-compose__body">
+                        <textarea name="message"
+                                  class="textarea"
+                                  placeholder="Kommentar hinzufügen…"
+                                  maxlength="2000"
+                                  required></textarea>
+                        <div class="activity-compose__actions">
+                            <button type="submit" class="btn btn--primary">
+                                <i class="bi bi-send"></i> Kommentieren
+                            </button>
+                        </div>
+                    </div>
+                </form>
             </div>
         </div>
 
@@ -584,34 +756,28 @@ html.light-mode .iss-root .report__avatar { background: var(--thw-blue); }
 
             <div class="card">
                 <div class="card-h">
-                    <span class="section-label">Bearbeitung</span>
+                    <span class="section-label">Status</span>
                 </div>
                 <form method="POST" action="{{ route('admin.issues.update', ['issue' => $issue->id, 'type' => $type]) }}">
                     @csrf
                     @method('PUT')
 
                     <div class="field">
-                        <label class="label">Status</label>
+                        <label class="label">Status ändern</label>
                         <select name="status" class="select">
                             <option value="open" {{ $issue->status === 'open' ? 'selected' : '' }}>Offen</option>
                             <option value="in_review" {{ $issue->status === 'in_review' ? 'selected' : '' }}>In Bearbeitung</option>
                             <option value="resolved" {{ $issue->status === 'resolved' ? 'selected' : '' }}>Gelöst</option>
                             <option value="rejected" {{ $issue->status === 'rejected' ? 'selected' : '' }}>Abgelehnt</option>
                         </select>
-                    </div>
-
-                    <div class="field">
-                        <label class="label">Notizen</label>
-                        <textarea name="admin_notes" class="textarea" maxlength="1000"
-                                  placeholder="Interne Notiz...">{{ $issue->admin_notes ?? '' }}</textarea>
-                        <div style="font-family: 'IBM Plex Mono', monospace; font-size: 0.625rem; color: var(--text-muted); margin-top: 0.25rem; letter-spacing: 0.06em;">
-                            <span id="noteCount">{{ strlen($issue->admin_notes ?? '') }}</span>/1000
+                        <div style="font-family: 'IBM Plex Mono', monospace; font-size: 0.625rem; color: var(--text-muted); margin-top: 0.4rem; letter-spacing: 0.06em;">
+                            Statuswechsel erscheinen als Eintrag in der Aktivität.
                         </div>
                     </div>
 
                     <div class="form-actions">
                         <button type="submit" class="btn btn--primary" style="flex: 1;">
-                            <i class="bi bi-check-lg"></i> Speichern
+                            <i class="bi bi-check-lg"></i> Status speichern
                         </button>
                         @if(auth()->user()->isAdmin())
                         <button type="button" onclick="confirmIssueDelete()" class="btn btn--danger">
@@ -637,11 +803,6 @@ html.light-mode .iss-root .report__avatar { background: var(--thw-blue); }
             document.getElementById('deleteForm').submit();
         }
     }
-
-    document.querySelector('textarea[name="admin_notes"]')?.addEventListener('input', function () {
-        const c = document.getElementById('noteCount');
-        if (c) c.textContent = this.value.length;
-    });
 
     // Inline question edit form: submit via fetch & redirect zurück zur Issue-Seite
     (function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -737,6 +737,7 @@ Route::middleware(['auth', \App\Http\Middleware\QuestionEditorMiddleware::class]
     Route::get('issues', [\App\Http\Controllers\Admin\IssueController::class, 'index'])->name('issues.index');
     Route::get('issues/{issue}', [\App\Http\Controllers\Admin\IssueController::class, 'show'])->name('issues.show');
     Route::put('issues/{issue}', [\App\Http\Controllers\Admin\IssueController::class, 'update'])->name('issues.update');
+    Route::post('issues/{issue}/comments', [\App\Http\Controllers\Admin\IssueController::class, 'storeComment'])->name('issues.comments.store');
 
     Route::get('lehrgang-issues', [\App\Http\Controllers\Admin\LehrgangIssueController::class, 'index'])->name('lehrgang-issues.index');
     Route::get('lehrgang-issues/{lehrgang_issue}', [\App\Http\Controllers\Admin\LehrgangIssueController::class, 'show'])->name('lehrgang-issues.show');


### PR DESCRIPTION
## Summary
Refactored the issue detail view to display a unified activity feed (Jira-style) combining reports, notes, and status changes. Replaced the separate "Meldungen" section with an integrated "Aktivität" feed and added inline comment composition.

## Key Changes

- **Activity Feed UI**: Redesigned reports section as a chronological activity feed with three activity types:
  - `report` - Initial issue reports with user avatar and message
  - `note` - Admin comments/notes with yellow badge styling
  - `status_change` - Status transitions with arrow icon and old→new status display

- **Database Schema**: Extended `*_issue_reports` tables with:
  - `type` column (string, default 'report') to distinguish activity types
  - `meta` column (JSON) to store status change metadata (old/new status)
  - Added indexes on `type` for efficient filtering

- **Controller Logic**:
  - Refactored `update()` to only handle status changes and log them as `status_change` activities
  - Added new `storeComment()` method to create `note` activities
  - Extracted `createActivity()` helper to standardize activity creation across both Lehrgang and Question issue types

- **Removed Features**:
  - Removed `admin_notes` textarea field (replaced by inline comments in activity feed)
  - Removed character counter for notes
  - Simplified "Bearbeitung" section to "Status" with status-change-only form

- **Styling**: Added comprehensive CSS for activity feed components:
  - `.activity-feed` container with flex layout
  - `.activity` base styles with type variants (`.activity--note`, `.activity--status`)
  - `.activity__avatar`, `.activity__badge`, `.activity__time` subcomponents
  - `.activity-compose` form for new comments with user avatar

- **Routes**: Added `admin.issues.comments.store` route for comment submission

## Implementation Details

- Activity list is sorted chronologically and includes a synthetic initial report entry if no reports exist but `latest_message` is present
- Status labels are localized (Offen, In Bearbeitung, Gelöst, Abgelehnt)
- Comment form uses same styling pattern as activity items for visual consistency
- All activity types support user attribution and timestamps
- Maintains backward compatibility with existing report data (type defaults to 'report')

https://claude.ai/code/session_01E6qtvnuvBAjZhsuZJaRTQo