### PR TITLE
✨: E-Mails für Fehlermeldung-Zuweisung & @Mentions

### DIFF
--- a/app/Http/Controllers/Admin/IssueController.php
+++ b/app/Http/Controllers/Admin/IssueController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Mail\IssueAssignedMail;
+use App\Mail\IssueMentionedMail;
 use App\Models\LehrgangQuestionIssue;
 use App\Models\LehrgangQuestionIssueReport;
 use App\Models\Notification;
@@ -10,7 +12,8 @@ use App\Models\QuestionIssue;
 use App\Models\QuestionIssueReport;
 use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
 
 class IssueController extends Controller
 {
@@ -254,7 +257,9 @@ class IssueController extends Controller
         ]);
 
         // Notify the new assignee (unless they assigned themselves)
-        if ($newUser && $newUser->id !== auth()->id()) {
+        if ($newUser && (int) $newUser->id !== (int) auth()->id()) {
+            $issueUrl = route('admin.issues.show', ['issue' => $issue->id, 'type' => $type]);
+
             Notification::create([
                 'user_id' => $newUser->id,
                 'type' => 'issue_assigned',
@@ -264,9 +269,28 @@ class IssueController extends Controller
                 'data' => [
                     'issue_id' => $issue->id,
                     'issue_type' => $type,
-                    'url' => route('admin.issues.show', ['issue' => $issue->id, 'type' => $type]),
+                    'url' => $issueUrl,
                 ],
             ]);
+
+            if (!empty($newUser->email)) {
+                try {
+                    Mail::to($newUser->email)->queue(new IssueAssignedMail(
+                        assignee: $newUser,
+                        assignedBy: auth()->user(),
+                        issueId: $issue->id,
+                        issueType: $type,
+                        questionText: $this->questionTextFor($issue, $type),
+                        issueUrl: $issueUrl,
+                    ));
+                } catch (\Throwable $e) {
+                    Log::warning('IssueAssignedMail konnte nicht in die Queue gelegt werden', [
+                        'issue_id' => $issue->id,
+                        'user_id' => $newUser->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
         }
 
         if ($request->wantsJson() || $request->ajax()) {
@@ -308,15 +332,19 @@ class IssueController extends Controller
             'mentioned_user_ids' => $mentionedUserIds,
         ]);
 
-        // Benachrichtigungen an erwähnte User (nicht an sich selbst)
+        // Benachrichtigungen + E-Mail an erwähnte User (nicht an sich selbst)
         if (!empty($mentionedUserIds)) {
             $currentUserId = auth()->id();
-            $authorName = auth()->user()->name ?? 'Jemand';
+            $author = auth()->user();
+            $authorName = $author->name ?? 'Jemand';
+            $issueUrl = route('admin.issues.show', ['issue' => $issue->id, 'type' => $type]);
+            $questionText = $this->questionTextFor($issue, $type);
 
             foreach (User::whereIn('id', $mentionedUserIds)->get() as $mentionedUser) {
                 if ((int) $mentionedUser->id === (int) $currentUserId) {
                     continue;
                 }
+
                 Notification::create([
                     'user_id' => $mentionedUser->id,
                     'type' => 'issue_mention',
@@ -326,9 +354,29 @@ class IssueController extends Controller
                     'data' => [
                         'issue_id' => $issue->id,
                         'issue_type' => $type,
-                        'url' => route('admin.issues.show', ['issue' => $issue->id, 'type' => $type]),
+                        'url' => $issueUrl,
                     ],
                 ]);
+
+                if (!empty($mentionedUser->email)) {
+                    try {
+                        Mail::to($mentionedUser->email)->queue(new IssueMentionedMail(
+                            mentioned: $mentionedUser,
+                            author: $author,
+                            issueId: $issue->id,
+                            issueType: $type,
+                            questionText: $questionText,
+                            commentMessage: $validated['message'],
+                            issueUrl: $issueUrl,
+                        ));
+                    } catch (\Throwable $e) {
+                        Log::warning('IssueMentionedMail konnte nicht in die Queue gelegt werden', [
+                            'issue_id' => $issue->id,
+                            'user_id' => $mentionedUser->id,
+                            'error' => $e->getMessage(),
+                        ]);
+                    }
+                }
             }
         }
 
@@ -377,6 +425,19 @@ class IssueController extends Controller
                 'meta' => $meta,
             ]);
         }
+    }
+
+    /**
+     * Liefert den Fragentext zum Issue (für E-Mails) — null wenn die Frage gelöscht ist.
+     */
+    private function questionTextFor($issue, string $type): ?string
+    {
+        if ($type === 'lehrgang') {
+            return $issue->lehrgangQuestion?->frage
+                ?? optional($issue->lehrgangQuestion()->first())?->frage;
+        }
+        return $issue->question?->frage
+            ?? optional($issue->question()->first())?->frage;
     }
 
     /**

--- a/app/Mail/IssueAssignedMail.php
+++ b/app/Mail/IssueAssignedMail.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class IssueAssignedMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public User $assignee,
+        public User $assignedBy,
+        public int $issueId,
+        public string $issueType,
+        public ?string $questionText,
+        public string $issueUrl,
+    ) {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: '[THW-Trainer] Fehlermeldung #' . $this->issueId . ' wurde dir zugewiesen',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.issue-assigned',
+        );
+    }
+
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Mail/IssueMentionedMail.php
+++ b/app/Mail/IssueMentionedMail.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class IssueMentionedMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public User $mentioned,
+        public User $author,
+        public int $issueId,
+        public string $issueType,
+        public ?string $questionText,
+        public string $commentMessage,
+        public string $issueUrl,
+    ) {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: '[THW-Trainer] ' . $this->author->name . ' hat dich erwähnt',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.issue-mentioned',
+        );
+    }
+
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/resources/views/emails/issue-assigned.blade.php
+++ b/resources/views/emails/issue-assigned.blade.php
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fehlermeldung zugewiesen - THW Trainer</title>
+</head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background:#f0f2f5;">
+    <div style="background:#f0f2f5;padding:32px 16px;">
+        <div style="max-width:600px;margin:0 auto;">
+
+            <div style="background:linear-gradient(135deg,#00337F,#0055cc);padding:20px 24px 16px;border-radius:1.5rem 0.5rem 0 0;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">
+                    <tr>
+                        <td width="32" height="32" align="center" valign="middle" style="width:32px;height:32px;background:rgba(255,255,255,0.15);border-radius:8px;text-align:center;vertical-align:middle;">
+                            <img src="{{ asset('logo-thw-trainer_w.png') . '?v=' . filemtime(public_path('logo-thw-trainer_w.png')) }}" alt="THW" width="18" height="18" style="display:block;margin:0 auto;width:18px;height:18px;border:0;">
+                        </td>
+                        <td valign="middle" style="vertical-align:middle;padding-left:10px;color:#fff;font-weight:700;font-size:14px;letter-spacing:0.5px;">THW-TRAINER</td>
+                    </tr>
+                </table>
+            </div>
+
+            <div style="background:#ffffff;padding:28px 24px;border-left:3px solid #00337F;box-shadow:0 4px 20px rgba(0,0,0,0.08);">
+                <div style="font-size:10px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;color:#64748b;margin-bottom:6px;">Fehlermeldung zugewiesen</div>
+                <div style="font-size:20px;font-weight:800;color:#0f172a;margin-bottom:16px;">Du hast eine neue Fehlermeldung</div>
+
+                <p style="margin:0 0 16px 0;font-size:13px;color:#475569;line-height:1.6;">
+                    Hallo <strong style="color:#0f172a;">{{ $assignee->name }}</strong>,
+                </p>
+
+                <p style="margin:0 0 16px 0;font-size:13px;color:#475569;line-height:1.6;">
+                    <strong style="color:#0f172a;">{{ $assignedBy->name }}</strong> hat dir die
+                    Fehlermeldung <strong style="color:#0f172a;">FM-{{ str_pad($issueId, 3, '0', STR_PAD_LEFT) }}</strong> zugewiesen.
+                </p>
+
+                @if($questionText)
+                    <div style="background:#f8fafc;border-radius:0.75rem;padding:14px 18px;margin-bottom:18px;border:1px solid rgba(0,51,127,0.10);">
+                        <div style="font-size:11px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:#64748b;margin-bottom:6px;">Betroffene Frage</div>
+                        <div style="font-size:14px;font-weight:600;color:#0f172a;line-height:1.5;">{{ \Illuminate\Support\Str::limit($questionText, 240) }}</div>
+                        <div style="font-size:12px;color:#64748b;margin-top:6px;">
+                            {{ $issueType === 'lehrgang' ? 'Lehrgang' : 'Grundausbildung' }}
+                        </div>
+                    </div>
+                @endif
+
+                <div style="text-align:center;margin:24px 0 8px;">
+                    <a href="{{ $issueUrl }}" style="background:linear-gradient(135deg,#00337F,#0055cc);color:#fff;padding:12px 32px;border-radius:0.5rem;text-decoration:none;font-weight:700;font-size:13px;display:inline-block;box-shadow:0 4px 15px rgba(0,51,127,0.3);">Fehlermeldung öffnen</a>
+                </div>
+
+                <p style="margin:18px 0 0 0;font-size:12px;color:#94a3b8;line-height:1.5;text-align:center;">
+                    Du erhältst diese E-Mail, weil dir eine Fehlermeldung im THW-Trainer Admin-Bereich zugewiesen wurde.
+                </p>
+            </div>
+
+            <div style="text-align:center;padding:18px 0;font-size:11px;color:#94a3b8;">
+                © {{ date('Y') }} THW-Trainer · <a href="{{ url('/') }}" style="color:#0055cc;text-decoration:none;">thw-trainer.de</a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/emails/issue-mentioned.blade.php
+++ b/resources/views/emails/issue-mentioned.blade.php
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Erwähnung in Fehlermeldung - THW Trainer</title>
+</head>
+@php
+    $renderedComment = preg_replace(
+        '/@([A-Za-zÄÖÜäöüß]+(?:\s[A-Za-zÄÖÜäöüß]+)?)/u',
+        '<span style="background:#e6efff;color:#00337F;padding:0 4px;border-radius:3px;font-weight:600;">@$1</span>',
+        e($commentMessage)
+    );
+@endphp
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background:#f0f2f5;">
+    <div style="background:#f0f2f5;padding:32px 16px;">
+        <div style="max-width:600px;margin:0 auto;">
+
+            <div style="background:linear-gradient(135deg,#00337F,#0055cc);padding:20px 24px 16px;border-radius:1.5rem 0.5rem 0 0;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">
+                    <tr>
+                        <td width="32" height="32" align="center" valign="middle" style="width:32px;height:32px;background:rgba(255,255,255,0.15);border-radius:8px;text-align:center;vertical-align:middle;">
+                            <img src="{{ asset('logo-thw-trainer_w.png') . '?v=' . filemtime(public_path('logo-thw-trainer_w.png')) }}" alt="THW" width="18" height="18" style="display:block;margin:0 auto;width:18px;height:18px;border:0;">
+                        </td>
+                        <td valign="middle" style="vertical-align:middle;padding-left:10px;color:#fff;font-weight:700;font-size:14px;letter-spacing:0.5px;">THW-TRAINER</td>
+                    </tr>
+                </table>
+            </div>
+
+            <div style="background:#ffffff;padding:28px 24px;border-left:3px solid #00337F;box-shadow:0 4px 20px rgba(0,0,0,0.08);">
+                <div style="font-size:10px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;color:#64748b;margin-bottom:6px;">Erwähnung</div>
+                <div style="font-size:20px;font-weight:800;color:#0f172a;margin-bottom:16px;">Du wurdest in einer Fehlermeldung erwähnt</div>
+
+                <p style="margin:0 0 16px 0;font-size:13px;color:#475569;line-height:1.6;">
+                    Hallo <strong style="color:#0f172a;">{{ $mentioned->name }}</strong>,
+                </p>
+
+                <p style="margin:0 0 16px 0;font-size:13px;color:#475569;line-height:1.6;">
+                    <strong style="color:#0f172a;">{{ $author->name }}</strong> hat dich in einem Kommentar zur
+                    Fehlermeldung <strong style="color:#0f172a;">FM-{{ str_pad($issueId, 3, '0', STR_PAD_LEFT) }}</strong> erwähnt.
+                </p>
+
+                <div style="background:#f8fafc;border-radius:0.75rem;padding:14px 18px;margin-bottom:18px;border-left:3px solid #5b9aff;">
+                    <div style="font-size:11px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:#64748b;margin-bottom:8px;">Kommentar</div>
+                    <div style="font-size:14px;color:#0f172a;line-height:1.6;white-space:pre-wrap;">{!! $renderedComment !!}</div>
+                </div>
+
+                @if($questionText)
+                    <div style="background:#f8fafc;border-radius:0.75rem;padding:14px 18px;margin-bottom:18px;border:1px solid rgba(0,51,127,0.10);">
+                        <div style="font-size:11px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:#64748b;margin-bottom:6px;">Betroffene Frage</div>
+                        <div style="font-size:14px;font-weight:600;color:#0f172a;line-height:1.5;">{{ \Illuminate\Support\Str::limit($questionText, 240) }}</div>
+                        <div style="font-size:12px;color:#64748b;margin-top:6px;">
+                            {{ $issueType === 'lehrgang' ? 'Lehrgang' : 'Grundausbildung' }}
+                        </div>
+                    </div>
+                @endif
+
+                <div style="text-align:center;margin:24px 0 8px;">
+                    <a href="{{ $issueUrl }}" style="background:linear-gradient(135deg,#00337F,#0055cc);color:#fff;padding:12px 32px;border-radius:0.5rem;text-decoration:none;font-weight:700;font-size:13px;display:inline-block;box-shadow:0 4px 15px rgba(0,51,127,0.3);">Antworten</a>
+                </div>
+
+                <p style="margin:18px 0 0 0;font-size:12px;color:#94a3b8;line-height:1.5;text-align:center;">
+                    Du erhältst diese E-Mail, weil du in einem Kommentar im Admin-Bereich erwähnt wurdest.
+                </p>
+            </div>
+
+            <div style="text-align:center;padding:18px 0;font-size:11px;color:#94a3b8;">
+                © {{ date('Y') }} THW-Trainer · <a href="{{ url('/') }}" style="color:#0055cc;text-decoration:none;">thw-trainer.de</a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Erweiterung des Fehlermeldung-Workflows (PR #541): Bei Zuweisung und @Erwähnung wird jetzt zusätzlich zur In-App-Benachrichtigung auch eine **E-Mail** versendet.

## What changed

- Neue Mailable [`IssueAssignedMail`](https://github.com/niclasreutter/THW-Trainer-App/blob/claude/clever-turing-43b523/app/Mail/IssueAssignedMail.php) — geht an den neu zugewiesenen User
- Neue Mailable [`IssueMentionedMail`](https://github.com/niclasreutter/THW-Trainer-App/blob/claude/clever-turing-43b523/app/Mail/IssueMentionedMail.php) — geht an jeden in einem Kommentar erwähnten User
- Zwei Email-Templates in `resources/views/emails/` im bestehenden THW-Trainer-Stil (blauer Gradient-Header, Karten-Layout, CTA-Button)
- Im `IssueMentionedMail` werden `@Mentions` im Kommentar-Text inline visuell hervorgehoben (gleiches Pattern wie in der UI)
- `IssueController::assign()` und `storeComment()` queuen die Mails per `Mail::to($user->email)->queue(...)` direkt nach dem Anlegen der DB-Notification
- Self-Mails werden vermieden (kein Versand wenn man sich selbst zuweist oder selbst erwähnt)
- Fehlende E-Mail-Adressen werden geräuschlos übersprungen
- Queue-Fehler werden geloggt aber blocken den Request nicht

## Reviewer notes

- Beide Mailables implementieren `ShouldQueue` — laufen also über die normale Queue (kein Sync-Send im Web-Request).
- `email_consent` wird hier bewusst **nicht** geprüft: Es geht um arbeits-/admin-relevante Benachrichtigungen für Admins/Contributors, kein Marketing.
- Push-Notifications via WebPush wurden nicht hinzugefügt (kann separat nachgereicht werden, falls erwünscht).

## Test plan

- [ ] Queue läuft (`php artisan queue:work`)
- [ ] Issue jemandem zuweisen → E-Mail kommt an, In-App-Notification existiert
- [ ] Sich selbst zuweisen → keine E-Mail
- [ ] Kommentar mit `@Vorname` → E-Mail an Erwähnten, Mention im E-Mail-Body als Chip hervorgehoben
- [ ] Sich selbst erwähnen → keine E-Mail
- [ ] User ohne E-Mail-Adresse → keine Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)