### PR TITLE
🎨: Contributor & Admin Dashboard Feinschliff

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -48,6 +48,7 @@ class DashboardController extends Controller
         $fragenQualitaet = $this->getFragenQualitaet($days);
         $ortsverbaende  = $this->getOrtsverbaende();
         $srStats        = $this->getSpacedRepetitionStats();
+        $submissionStats = $this->getSubmissionStats();
         $liveFeed       = $this->getLiveFeed();
 
         return view('admin.dashboard', compact(
@@ -59,8 +60,23 @@ class DashboardController extends Controller
             'fragenQualitaet',
             'ortsverbaende',
             'srStats',
+            'submissionStats',
             'liveFeed'
         ));
+    }
+
+    /* =========================================================
+       EINREICHUNGS-STATUS — Zusatz-Fragen-Vorschläge
+       ========================================================= */
+    private function getSubmissionStats(): array
+    {
+        return [
+            'total'    => UserExtraQuestionSubmission::count(),
+            'pending'  => UserExtraQuestionSubmission::where('status', 'pending')->count(),
+            'approved' => UserExtraQuestionSubmission::where('status', 'approved')->count(),
+            'changed'  => UserExtraQuestionSubmission::where('status', 'changed')->count(),
+            'rejected' => UserExtraQuestionSubmission::where('status', 'rejected')->count(),
+        ];
     }
 
     /* =========================================================

--- a/app/Http/Controllers/Contributor/DashboardController.php
+++ b/app/Http/Controllers/Contributor/DashboardController.php
@@ -15,58 +15,12 @@ class DashboardController extends Controller
     public function index()
     {
         return view('contributor.dashboard', [
-            'statusBar'         => $this->getStatusBar(),
             'kpis'              => $this->getKpis(),
             'handlungsbedarf'   => $this->getHandlungsbedarf(),
             'recentSubmissions' => $this->getRecentSubmissions(),
             'submissionStats'   => $this->getSubmissionStats(),
             'recentIssues'      => $this->getRecentIssues(),
         ]);
-    }
-
-    /* =========================================================
-       STATUS BAR — analog zur System-Puls Bar im Admin Dashboard
-       ========================================================= */
-    private function getStatusBar(): array
-    {
-        $totalFragen      = Question::count();
-        $entwuerfe        = Question::whereNull('loesung')->orWhere('loesung', '')->count();
-        $totalExtra       = ExtraQuestion::count();
-        $pendingSubmissions = UserExtraQuestionSubmission::where('status', 'pending')->count();
-        $openIssues       = QuestionIssue::where('status', 'open')->count()
-                          + LehrgangQuestionIssue::where('status', 'open')->count();
-        $totalLehrgaenge  = Lehrgang::count();
-
-        return [
-            'fragen' => [
-                'status' => $entwuerfe > 0 ? 'warn' : 'ok',
-                'label'  => 'Fragen-Pool',
-                'value'  => number_format($totalFragen, 0, ',', '.'),
-                'sub'    => $entwuerfe . ' ' . ($entwuerfe === 1 ? 'Entwurf' : 'Entwürfe'),
-                'link'   => route('admin.questions.index'),
-            ],
-            'zusatz' => [
-                'status' => $pendingSubmissions >= 3 ? 'warn' : 'ok',
-                'label'  => 'Zusatz-Fragen',
-                'value'  => number_format($totalExtra, 0, ',', '.'),
-                'sub'    => $pendingSubmissions . ' ' . ($pendingSubmissions === 1 ? 'Vorschlag offen' : 'Vorschläge offen'),
-                'link'   => route('admin.extra-question-submissions.index', ['status' => 'pending']),
-            ],
-            'lehrgaenge' => [
-                'status' => 'ok',
-                'label'  => 'Lehrgänge',
-                'value'  => number_format($totalLehrgaenge, 0, ',', '.'),
-                'sub'    => 'Kurse zum Bearbeiten',
-                'link'   => route('admin.lehrgaenge.index'),
-            ],
-            'issues' => [
-                'status' => $openIssues === 0 ? 'ok' : ($openIssues >= 5 ? 'err' : 'warn'),
-                'label'  => 'Fehlermeldungen',
-                'value'  => $openIssues === 0 ? 'Keine offen' : $openIssues . ' offen',
-                'sub'    => 'Issues zur Bearbeitung',
-                'link'   => route('admin.issues.index'),
-            ],
-        ];
     }
 
     /* =========================================================

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -292,6 +292,10 @@ html.light-mode .admin-root .sr-tile { border-color: rgba(0,51,127,0.08); backgr
 .admin-root .sr-tile__val--gold  { color: #fbbf24; }
 .admin-root .sr-tile__val--green { color: #22c55e; }
 .admin-root .sr-tile__val--purp  { color: #a78bfa; }
+.admin-root .sr-tile__val--blue  { color: #5b9aff; }
+html.light-mode .admin-root .sr-tile__val--blue { color: var(--thw-blue); }
+.admin-root .sr-tile__val--red   { color: #ef4444; }
+.admin-root .sr-stats--4 { grid-template-columns: repeat(4, 1fr); }
 .admin-root .sr-tile__lbl {
     font-family: 'IBM Plex Mono', monospace; font-size: 0.625rem; font-weight: 600;
     text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted);
@@ -316,6 +320,7 @@ html.light-mode .admin-root .sr-dist { background: rgba(0,51,127,0.08); }
     .admin-root .pulse-item + .pulse-item:nth-child(3) { border-left: 0; padding-left: 0; }
     .admin-root .admin-grid, .admin-root .admin-grid--wide { grid-template-columns: 1fr; }
     .admin-root .charts-grid { grid-template-columns: 1fr; }
+    .admin-root .sr-stats--4 { grid-template-columns: repeat(2, 1fr); }
 }
 @media (max-width: 700px) {
     .admin-root .kpi-grid { grid-template-columns: repeat(2, 1fr); }
@@ -748,6 +753,57 @@ html.light-mode .admin-root .sr-dist { background: rgba(0,51,127,0.08); }
             </div>
         </div>
 
+    </div>
+
+    {{-- ── ROW 4: EINREICHUNGS-STATUS ─────────── --}}
+    <div class="card" style="margin-bottom: 1rem;">
+        <div class="card-h">
+            <span class="section-label">Einreichungs-Status</span>
+            <a href="{{ route('admin.extra-question-submissions.index') }}" class="card-h-link">Verwalten →</a>
+        </div>
+
+        <div class="sr-stats sr-stats--4">
+            <div class="sr-tile">
+                <div class="sr-tile__val sr-tile__val--blue">{{ $submissionStats['pending'] }}</div>
+                <div class="sr-tile__lbl">Offen</div>
+            </div>
+            <div class="sr-tile">
+                <div class="sr-tile__val sr-tile__val--green">{{ $submissionStats['approved'] }}</div>
+                <div class="sr-tile__lbl">Übernommen</div>
+            </div>
+            <div class="sr-tile">
+                <div class="sr-tile__val sr-tile__val--gold">{{ $submissionStats['changed'] }}</div>
+                <div class="sr-tile__lbl">Geändert</div>
+            </div>
+            <div class="sr-tile">
+                <div class="sr-tile__val sr-tile__val--red">{{ $submissionStats['rejected'] }}</div>
+                <div class="sr-tile__lbl">Abgelehnt</div>
+            </div>
+        </div>
+
+        @php
+            $totalSubs = max($submissionStats['total'], 1);
+            $pctPending  = round(($submissionStats['pending'] / $totalSubs) * 100);
+            $pctApproved = round(($submissionStats['approved'] / $totalSubs) * 100);
+            $pctChanged  = round(($submissionStats['changed'] / $totalSubs) * 100);
+            $pctRejected = round(($submissionStats['rejected'] / $totalSubs) * 100);
+        @endphp
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.375rem;">
+            <span class="section-label" style="font-size:0.625rem;">Verteilung</span>
+            <span style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;color:var(--text-muted);">{{ number_format($submissionStats['total'], 0, ',', '.') }} Einreichungen</span>
+        </div>
+        <div style="display:flex;height:12px;border-radius:999px;overflow:hidden;margin-bottom:0.625rem;background:rgba(255,255,255,0.06);">
+            <div style="width:{{ $pctPending }}%;background:#5b9aff;"></div>
+            <div style="width:{{ $pctApproved }}%;background:#22c55e;"></div>
+            <div style="width:{{ $pctChanged }}%;background:#fbbf24;"></div>
+            <div style="width:{{ $pctRejected }}%;background:#ef4444;"></div>
+        </div>
+        <div style="display:flex;flex-wrap:wrap;gap:0.875rem;font-size:0.6875rem;color:var(--text-muted);">
+            <div style="display:inline-flex;align-items:center;gap:0.35rem;"><span style="width:8px;height:8px;border-radius:2px;background:#5b9aff;"></span>Offen · {{ $pctPending }}%</div>
+            <div style="display:inline-flex;align-items:center;gap:0.35rem;"><span style="width:8px;height:8px;border-radius:2px;background:#22c55e;"></span>Übernommen · {{ $pctApproved }}%</div>
+            <div style="display:inline-flex;align-items:center;gap:0.35rem;"><span style="width:8px;height:8px;border-radius:2px;background:#fbbf24;"></span>Geändert · {{ $pctChanged }}%</div>
+            <div style="display:inline-flex;align-items:center;gap:0.35rem;"><span style="width:8px;height:8px;border-radius:2px;background:#ef4444;"></span>Abgelehnt · {{ $pctRejected }}%</div>
+        </div>
     </div>
 
 </div>

--- a/resources/views/contributor/dashboard.blade.php
+++ b/resources/views/contributor/dashboard.blade.php
@@ -319,33 +319,6 @@ html.light-mode .admin-root .sr-tile__val--blue { color: var(--thw-blue); }
         </div>
     </div>
 
-    {{-- ── STATUS BAR ──────────────────────────── --}}
-    <div class="sys-pulse" role="status" aria-label="Status-Übersicht">
-        @foreach($statusBar as $item)
-            @php $href = $item['link'] ?? null; @endphp
-            @if($href)
-                <a class="pulse-item pulse-item--link" href="{{ $href }}" title="Details öffnen">
-                    <span class="pulse-dot pulse-dot--{{ $item['status'] }}"></span>
-                    <div class="pulse-meta">
-                        <div class="pulse-label">{{ $item['label'] }}</div>
-                        <div class="pulse-value">{{ $item['value'] }}</div>
-                        <div class="pulse-sub">{{ $item['sub'] }}</div>
-                    </div>
-                    <i class="bi bi-chevron-right pulse-chevron" aria-hidden="true"></i>
-                </a>
-            @else
-                <div class="pulse-item">
-                    <span class="pulse-dot pulse-dot--{{ $item['status'] }}"></span>
-                    <div class="pulse-meta">
-                        <div class="pulse-label">{{ $item['label'] }}</div>
-                        <div class="pulse-value">{{ $item['value'] }}</div>
-                        <div class="pulse-sub">{{ $item['sub'] }}</div>
-                    </div>
-                </div>
-            @endif
-        @endforeach
-    </div>
-
     {{-- ── KPI GRID ─────────────────────────────── --}}
     <div class="kpi-grid">
         @foreach($kpis as $key => $kpi)
@@ -501,7 +474,12 @@ html.light-mode .admin-root .sr-tile__val--blue { color: var(--thw-blue); }
             </div>
             <div class="feed">
                 @forelse($recentIssues as $i)
-                    <a href="{{ route('admin.issues.index') }}" class="feed-item">
+                    @php
+                        $issueLink = $i['kind'] === 'lehrgang'
+                            ? route('admin.lehrgang-issues.show', $i['id'])
+                            : route('admin.issues.show', $i['id']);
+                    @endphp
+                    <a href="{{ $issueLink }}" class="feed-item">
                         <div class="feed-icon feed-icon--red">
                             <i class="bi bi-bug-fill"></i>
                         </div>


### PR DESCRIPTION
## Summary

- **Contributor Dashboard:** Status-Bar (Fragen-Pool / Zusatz-Fragen / Lehrgänge / Fehlermeldungen) entfernt — redundant zu den KPI-Cards darunter.
- **Contributor Dashboard:** Klicks auf einzelne Fehlermeldungen im Feed öffnen jetzt direkt die jeweilige Issue-Detailseite (`admin.issues.show` / `admin.lehrgang-issues.show`) statt der Übersicht.
- **Admin Dashboard:** Neue "Einreichungs-Status"-Karte (Offen / Übernommen / Geändert / Abgelehnt + Verteilungsbalken) — identisch zur bestehenden Karte im Contributor Dashboard.

## Änderungen

- `app/Http/Controllers/Contributor/DashboardController.php` — `getStatusBar()` und zugehöriger View-Param entfernt.
- `resources/views/contributor/dashboard.blade.php` — `sys-pulse`-Block entfernt; Issue-Feed-Items routen nach `kind` (`question` / `lehrgang`) auf die richtige Show-Route.
- `app/Http/Controllers/Admin/DashboardController.php` — `getSubmissionStats()` ergänzt.
- `resources/views/admin/dashboard.blade.php` — neue Row mit Einreichungs-Status-Karte; CSS um `sr-tile__val--blue/--red` und `sr-stats--4` (inkl. Responsive-Fallback) erweitert.

## Test plan

- [ ] Contributor Dashboard öffnen → Status-Bar ist weg, KPI-Grid ist erste sichtbare Komponente
- [ ] Eintrag in "Aktuelle Fehlermeldungen" klicken → öffnet direkt die Issue-Detailseite (sowohl Question- als auch Lehrgang-Issue)
- [ ] Admin Dashboard öffnen → neue Einreichungs-Status-Karte am Ende der Seite, Tiles und Verteilungsbalken korrekt
- [ ] Responsive: < 1100 px schaltet die 4er-Tile-Grid auf 2 Spalten um

🤖 Generated with [Claude Code](https://claude.com/claude-code)