### PR TITLE
🐛: Fehlermeldungs-Link mit type-Param

### DIFF
--- a/resources/views/contributor/dashboard.blade.php
+++ b/resources/views/contributor/dashboard.blade.php
@@ -474,12 +474,7 @@ html.light-mode .admin-root .sr-tile__val--blue { color: var(--thw-blue); }
             </div>
             <div class="feed">
                 @forelse($recentIssues as $i)
-                    @php
-                        $issueLink = $i['kind'] === 'lehrgang'
-                            ? route('admin.lehrgang-issues.show', $i['id'])
-                            : route('admin.issues.show', $i['id']);
-                    @endphp
-                    <a href="{{ $issueLink }}" class="feed-item">
+                    <a href="{{ route('admin.issues.show', ['issue' => $i['id'], 'type' => $i['kind']]) }}" class="feed-item">
                         <div class="feed-icon feed-icon--red">
                             <i class="bi bi-bug-fill"></i>
                         </div>


### PR DESCRIPTION
## Summary

- Issue-Links im Contributor-Dashboard nutzen jetzt einheitlich `admin.issues.show` mit `?type=question` bzw. `?type=lehrgang` statt der separaten Routen `/admin/issues/{id}` und `/admin/lehrgang-issues/{id}`.

## Why

Der `IssueController::show` unterstützt beide Typen über den `type`-Query-Parameter — die zwei Codepfade zur Detail-Seite (`admin.issues.show` vs. `admin.lehrgang-issues.show`) waren inkonsistent. Jetzt ein einheitliches URL-Schema.

## Test plan

- [ ] Contributor Dashboard → Question-Fehlermeldung anklicken → öffnet `/admin/issues/{id}?type=question`
- [ ] Contributor Dashboard → Lehrgang-Fehlermeldung anklicken → öffnet `/admin/issues/{id}?type=lehrgang`
- [ ] Beide Detail-Seiten laden korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)