### PR TITLE
🐛: Fix matching question category select binding

### DIFF
--- a/resources/views/admin/extra-questions/partials/form-matching.blade.php
+++ b/resources/views/admin/extra-questions/partials/form-matching.blade.php
@@ -116,7 +116,11 @@
                        x-model="it.text"
                        placeholder="Item-Text (z.B. 'Mastwurf')" required>
                 <div class="zf-pair__arrow"><i class="bi bi-arrow-down"></i></div>
-                <select class="zf-select" :name="`items[${i}][category_index]`" x-model.number="it.category_index" required>
+                <select class="zf-select"
+                        :name="`items[${i}][category_index]`"
+                        x-model.number="it.category_index"
+                        x-init="$nextTick(() => { $el.value = it.category_index })"
+                        required>
                     <template x-for="(cat, ci) in categories" :key="ci">
                         <option :value="ci" x-text="(ci + 1) + '. ' + (cat.name || 'Kategorie ' + (ci + 1))"></option>
                     </template>


### PR DESCRIPTION
## Summary
Fixes a bug in the matching question form where the category dropdown (`<select>`) element was not properly reflecting the initial value from the Alpine.js data model on page load.

## Key Changes
- Added `x-init` directive with `$nextTick()` callback to the category select element
- Explicitly sets the select element's value to match the `it.category_index` data property after DOM initialization
- Reformatted the select tag attributes for better readability (multi-line)

## Implementation Details
The issue occurred because Alpine.js's `x-model` binding on a `<select>` element sometimes fails to sync the initial value if the options are rendered dynamically via `x-for`. By using `x-init` with `$nextTick()`, we ensure the value is set after Alpine has finished rendering the option elements, guaranteeing the correct category is selected when the form loads.

This is a common pattern when working with dynamically populated select elements in Alpine.js.

https://claude.ai/code/session_017yW7CF9MG1TebgKZugCBUK