### PR TITLE
🎨: Aushang-Ausdruck 1:1 an Design angepasst

### DIFF
--- a/resources/views/ortsverband/invitations/aushang.blade.php
+++ b/resources/views/ortsverband/invitations/aushang.blade.php
@@ -10,28 +10,17 @@
     <title>Aushang {{ $ortsverband->name }} - THW-Trainer</title>
     <meta name="robots" content="noindex, nofollow">
     <link rel="preconnect" href="https://fonts.bunny.net">
-    <link href="https://fonts.bunny.net/css2?family=Barlow+Condensed:wght@600;700;800&family=Figtree:wght@400;500;600;700&family=IBM+Plex+Mono:wght@500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.bunny.net/css2?family=Barlow+Condensed:wght@700;800&family=Figtree:wght@400;500;600;700&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
     <style>
-        :root {
-            --thw-blue: #00337F;
-            --thw-blue-dark: #002255;
-            --gold-start: #fbbf24;
-            --gold-end: #f59e0b;
-            --ink: #0f172a;
-            --muted: #64748b;
-        }
-
         * { box-sizing: border-box; margin: 0; padding: 0; }
 
         html, body {
-            background: #e2e8f0;
-            font-family: 'Figtree', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-            color: var(--ink);
+            background: #e5e7eb;
             -webkit-print-color-adjust: exact;
             print-color-adjust: exact;
         }
 
-        /* ---- Print toolbar (nicht im Druck) ---- */
+        /* ---- Bildschirm-Toolbar (nicht im Druck) ---- */
         .toolbar {
             position: sticky;
             top: 0;
@@ -43,6 +32,7 @@
             padding: 0.85rem 1rem;
             background: rgba(15, 23, 42, 0.96);
             backdrop-filter: blur(8px);
+            font-family: 'Figtree', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
         }
         .toolbar__hint {
             color: #cbd5e1;
@@ -62,339 +52,119 @@
             display: inline-flex;
             align-items: center;
             gap: 0.4rem;
-            transition: transform 0.12s ease, filter 0.12s ease;
+            transition: transform 0.12s ease;
         }
         .tb-btn:hover { transform: translateY(-1px); }
-        .tb-btn--primary {
-            background: linear-gradient(135deg, var(--gold-start), var(--gold-end));
-            color: #3a2a00;
-        }
-        .tb-btn--ghost {
-            background: rgba(255, 255, 255, 0.12);
-            color: #e2e8f0;
-        }
+        .tb-btn--primary { background: #00337F; color: #fff; }
+        .tb-btn--ghost { background: rgba(255, 255, 255, 0.12); color: #e2e8f0; }
 
         /* ---- A4 Blatt ---- */
         .sheet {
             width: 210mm;
-            min-height: 297mm;
-            margin: 1.5rem auto;
-            background: #fff;
-            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+            height: 297mm;
+            margin: 24px auto;
+            background: #ffffff;
+            color: #1e293b;
+            font-family: 'Figtree', ui-sans-serif, system-ui, sans-serif;
             display: flex;
             flex-direction: column;
+            position: relative;
             overflow: hidden;
+            box-shadow: 0 8px 28px rgba(0, 51, 127, 0.10);
         }
 
-        /* Kopf-Band THW-Blau */
-        .sheet__head {
-            background: linear-gradient(135deg, var(--thw-blue), var(--thw-blue-dark));
-            color: #fff;
-            padding: 14mm 16mm 12mm;
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            position: relative;
-        }
-        .sheet__head::after {
-            content: "";
-            position: absolute;
-            left: 0; right: 0; bottom: 0;
-            height: 4px;
-            background: linear-gradient(90deg, var(--gold-start), var(--gold-end));
-        }
-        .brand-logo {
-            height: 42px;
-            width: auto;
-            background: #fff;
-            border-radius: 10px;
-            padding: 5px 8px;
-        }
-        .brand-name {
-            font-family: 'Barlow Condensed', sans-serif;
-            font-weight: 800;
-            font-size: 1.9rem;
-            letter-spacing: 0.5px;
-            line-height: 1;
-        }
-        .brand-tag {
-            margin-left: auto;
-            text-align: right;
-            font-size: 0.72rem;
-            letter-spacing: 0.14em;
-            text-transform: uppercase;
-            color: rgba(255, 255, 255, 0.78);
-            font-weight: 600;
-        }
-
-        /* Body */
-        .sheet__body {
-            flex: 1;
-            padding: 12mm 16mm 6mm;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            text-align: center;
-        }
-        .kicker {
-            font-family: 'IBM Plex Mono', monospace;
-            font-weight: 700;
-            font-size: 0.72rem;
-            letter-spacing: 0.22em;
-            text-transform: uppercase;
-            color: var(--gold-end);
-            margin-bottom: 10px;
-        }
-        .headline {
-            font-family: 'Barlow Condensed', sans-serif;
-            font-weight: 800;
-            font-size: 3.5rem;
-            line-height: 0.98;
-            color: var(--thw-blue);
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        .headline span {
-            display: block;
-            background: linear-gradient(135deg, var(--gold-start), var(--gold-end));
-            -webkit-background-clip: text;
-            background-clip: text;
-            -webkit-text-fill-color: transparent;
-            color: var(--gold-end);
-        }
-        .subline {
-            margin-top: 10px;
-            font-size: 1.05rem;
-            color: var(--muted);
-            max-width: 135mm;
-            line-height: 1.5;
-        }
-
-        /* QR Karte */
-        .qr-card {
-            margin: 9mm 0 6mm;
-            background: #fff;
-            border: 3px solid var(--thw-blue);
-            border-radius: 18px;
-            padding: 16px;
-            box-shadow: 0 10px 30px rgba(0, 51, 127, 0.14);
-            position: relative;
-        }
-        .qr-card::before {
-            content: "SCANNEN & MITMACHEN";
-            position: absolute;
-            top: -13px;
-            left: 50%;
-            transform: translateX(-50%);
-            background: linear-gradient(135deg, var(--gold-start), var(--gold-end));
-            color: #3a2a00;
-            font-family: 'IBM Plex Mono', monospace;
-            font-weight: 700;
-            font-size: 0.62rem;
-            letter-spacing: 0.14em;
-            padding: 4px 12px;
-            border-radius: 999px;
-            white-space: nowrap;
-        }
-        .qr-card img {
-            display: block;
-            width: 62mm;
-            height: 62mm;
-        }
-        .ov-line {
-            font-size: 1.15rem;
-            font-weight: 700;
-            color: var(--ink);
-        }
-        .ov-line b { color: var(--thw-blue); }
-        .code-line {
-            margin-top: 4px;
-            font-size: 0.85rem;
-            color: var(--muted);
-        }
-        .code-line code {
-            font-family: 'IBM Plex Mono', monospace;
-            font-weight: 700;
-            font-size: 0.92rem;
-            color: var(--ink);
-            background: #f1f5f9;
-            border: 1px solid #e2e8f0;
-            border-radius: 6px;
-            padding: 2px 8px;
-            letter-spacing: 0.04em;
-        }
-
-        /* Schritte */
-        .steps {
-            display: flex;
-            gap: 10px;
-            margin-top: 9mm;
-            width: 100%;
-            max-width: 165mm;
-        }
-        .step {
-            flex: 1;
-            border: 1px solid #e2e8f0;
-            border-radius: 12px;
-            padding: 12px 10px;
-            background: #f8fafc;
-        }
-        .step__num {
-            width: 30px;
-            height: 30px;
-            margin: 0 auto 8px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            border-radius: 999px;
-            background: linear-gradient(135deg, var(--thw-blue), var(--thw-blue-dark));
-            color: #fff;
-            font-family: 'Barlow Condensed', sans-serif;
-            font-weight: 800;
-            font-size: 1.05rem;
-        }
-        .step__title {
-            font-weight: 700;
-            font-size: 0.92rem;
-            color: var(--ink);
-            margin-bottom: 2px;
-        }
-        .step__text {
-            font-size: 0.76rem;
-            color: var(--muted);
-            line-height: 1.35;
-        }
-
-        /* Benefits */
-        .benefits {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
-            margin-top: 8mm;
-        }
-        .benefit {
-            font-size: 0.8rem;
-            font-weight: 600;
-            color: var(--thw-blue);
-            background: rgba(0, 51, 127, 0.06);
-            border: 1px solid rgba(0, 51, 127, 0.12);
-            border-radius: 999px;
-            padding: 5px 12px;
-        }
-
-        /* Fuß-Band */
-        .sheet__foot {
-            margin-top: auto;
-            background: var(--thw-blue-dark);
-            color: #fff;
-            padding: 8mm 16mm;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 12px;
-        }
-        .foot-url {
-            font-family: 'Barlow Condensed', sans-serif;
-            font-weight: 800;
-            font-size: 1.5rem;
-            letter-spacing: 0.5px;
-        }
-        .foot-url span {
-            background: linear-gradient(135deg, var(--gold-start), var(--gold-end));
-            -webkit-background-clip: text;
-            background-clip: text;
-            -webkit-text-fill-color: transparent;
-        }
-        .foot-note {
-            font-size: 0.78rem;
-            color: rgba(255, 255, 255, 0.72);
-            text-align: right;
-            line-height: 1.4;
-        }
-
-        /* ---- Druck ---- */
-        @page {
-            size: A4;
-            margin: 0;
-        }
+        @page { size: A4; margin: 0; }
         @media print {
             html, body { background: #fff; }
             .toolbar { display: none !important; }
-            .sheet {
-                margin: 0;
-                box-shadow: none;
-                width: 210mm;
-                min-height: 297mm;
-            }
+            .sheet { margin: 0; box-shadow: none; }
         }
     </style>
 </head>
 <body>
-    <div class="toolbar no-print">
+    <div class="toolbar">
         <span class="toolbar__hint">Tipp: Im Druckdialog „Als PDF speichern&#8220; wählen &middot; Ränder: Keine</span>
         <button type="button" class="tb-btn tb-btn--primary" onclick="window.print()">Als PDF speichern / Drucken</button>
         <a href="{{ route('ortsverband.invitations.index', $ortsverband) }}" class="tb-btn tb-btn--ghost">Zurück</a>
     </div>
 
     <div class="sheet">
-        <div class="sheet__head">
-            @if($logoDataUri)
-                <img src="{{ $logoDataUri }}" alt="THW-Trainer" class="brand-logo">
-            @endif
-            <span class="brand-name">THW-Trainer</span>
-            <span class="brand-tag">Lern- &amp;<br>Prüfungsplattform</span>
-        </div>
 
-        <div class="sheet__body">
-            <div class="kicker">Für alle in der Grundausbildung</div>
-            <h1 class="headline">
-                Übe für deine
-                <span>THW-Prüfung</span>
-            </h1>
-            <p class="subline">
-                Theoriefragen üben, Prüfungen simulieren und deinen Fortschritt verfolgen &ndash;
-                kostenlos und direkt auf dem Handy. Scanne den Code und leg los.
-            </p>
+        <div style="height: 8px; background: #00337F; flex: 0 0 auto;"></div>
 
-            <div class="qr-card">
-                <img src="{{ $qrDataUri }}" alt="QR-Code zur Registrierung für {{ $ortsverband->name }}">
+        <div style="flex: 1; display: flex; flex-direction: column; padding: 44px 56px 40px 56px; min-height: 0;">
+
+            <div style="display: flex; align-items: center; justify-content: space-between;">
+                <div style="display: flex; align-items: center; gap: 14px;">
+                    @if($logoDataUri)
+                        <img src="{{ $logoDataUri }}" alt="THW-Trainer Logo" style="width: 46px; height: 46px; display: block;" />
+                    @endif
+                    <div style="display: flex; flex-direction: column; gap: 2px;">
+                        <div style="font-family: 'Barlow Condensed', sans-serif; font-weight: 800; font-size: 27px; line-height: 1; color: #00337F; letter-spacing: 0.005em;">THW-Trainer</div>
+                        <div style="font-family: 'IBM Plex Mono', monospace; font-weight: 500; font-size: 10px; letter-spacing: 0.14em; color: #64748b;">LERN- &amp; PRÜFUNGSPLATTFORM</div>
+                    </div>
+                </div>
+                <div style="font-family: 'IBM Plex Mono', monospace; font-weight: 600; font-size: 11px; letter-spacing: 0.10em; color: #00337F; background: rgba(0,51,127,0.06); border: 1px solid rgba(0,51,127,0.15); border-radius: 9999px; padding: 8px 16px;">SCANNEN &amp; MITMACHEN</div>
             </div>
 
-            <div class="ov-line">Ortsverband <b>{{ $ortsverband->name }}</b></div>
-            <div class="code-line">Kein Scanner? Auf {{ $host }} registrieren, Code: <code>{{ $invitation->code }}</code></div>
+            <div style="margin-top: 46px;">
+                <div style="font-family: 'IBM Plex Mono', monospace; font-weight: 600; font-size: 12px; letter-spacing: 0.12em; color: #64748b; border-left: 3px solid #d97706; padding-left: 12px;">FÜR ALLE IN DER GRUNDAUSBILDUNG</div>
+                <div style="font-family: 'Barlow Condensed', sans-serif; font-weight: 800; font-size: 64px; line-height: 1.02; letter-spacing: -0.005em; color: #00337F; margin-top: 16px;">Übe die Theorie der<br />Grundausbildung.</div>
+                <p style="font-size: 17px; line-height: 1.5; color: #475569; max-width: 540px; margin: 18px 0 0 0;">Theoriefragen üben, Prüfungen simulieren und deinen Fortschritt verfolgen, kostenlos und direkt auf dem Handy.</p>
+            </div>
 
-            <div class="steps">
-                <div class="step">
-                    <div class="step__num">1</div>
-                    <div class="step__title">Scannen</div>
-                    <div class="step__text">QR-Code mit der Handy-Kamera aufnehmen.</div>
+            <div style="display: flex; gap: 36px; margin-top: 42px; align-items: stretch;">
+
+                <div style="flex: 0 0 320px; background: #ffffff; border: 1px solid rgba(0,51,127,0.15); border-radius: 24px 8px 24px 8px; box-shadow: 0 4px 16px rgba(0,51,127,0.08); padding: 24px 24px 22px 24px; display: flex; flex-direction: column; align-items: center; gap: 16px;">
+                    <img src="{{ $qrDataUri }}" alt="QR-Code zur Registrierung für {{ $ortsverband->name }}" style="width: 256px; height: 256px; display: block;" />
+                    <div style="display: flex; flex-direction: column; align-items: center; gap: 7px; text-align: center;">
+                        <div style="font-family: 'IBM Plex Mono', monospace; font-weight: 500; font-size: 10px; letter-spacing: 0.14em; color: #64748b;">DEIN ORTSVERBAND</div>
+                        <div style="font-weight: 700; font-size: 18px; line-height: 1.2; color: #1e293b;">{{ $ortsverband->name }}</div>
+                        <div style="font-family: 'IBM Plex Mono', monospace; font-weight: 600; font-size: 14px; letter-spacing: 0.06em; color: #00337F; background: rgba(0,51,127,0.06); border: 1px solid rgba(0,51,127,0.15); border-radius: 9999px; padding: 5px 14px;">{{ $invitation->code }}</div>
+                    </div>
                 </div>
-                <div class="step">
-                    <div class="step__num">2</div>
-                    <div class="step__title">Registrieren</div>
-                    <div class="step__text">Kostenlos anmelden &ndash; du trittst dem OV automatisch bei.</div>
-                </div>
-                <div class="step">
-                    <div class="step__num">3</div>
-                    <div class="step__title">Loslegen</div>
-                    <div class="step__text">Sofort für die Grundausbildung lernen.</div>
+
+                <div style="flex: 1; display: flex; flex-direction: column; justify-content: space-between; padding: 4px 0;">
+                    <div style="display: flex; flex-direction: column; gap: 22px;">
+                        <div style="display: flex; align-items: flex-start; gap: 16px;">
+                            <div style="flex: 0 0 auto; width: 42px; height: 42px; background: #00337F; color: #ffffff; border-radius: 12px 4px 12px 4px; display: flex; align-items: center; justify-content: center; font-family: 'Barlow Condensed', sans-serif; font-weight: 800; font-size: 21px;">1</div>
+                            <div style="display: flex; flex-direction: column; gap: 3px;">
+                                <div style="font-weight: 700; font-size: 17px; color: #1e293b;">Scannen</div>
+                                <div style="font-size: 14px; line-height: 1.45; color: #64748b;">QR-Code mit der Handy-Kamera aufnehmen.</div>
+                            </div>
+                        </div>
+                        <div style="display: flex; align-items: flex-start; gap: 16px;">
+                            <div style="flex: 0 0 auto; width: 42px; height: 42px; background: #00337F; color: #ffffff; border-radius: 12px 4px 12px 4px; display: flex; align-items: center; justify-content: center; font-family: 'Barlow Condensed', sans-serif; font-weight: 800; font-size: 21px;">2</div>
+                            <div style="display: flex; flex-direction: column; gap: 3px;">
+                                <div style="font-weight: 700; font-size: 17px; color: #1e293b;">Registrieren</div>
+                                <div style="font-size: 14px; line-height: 1.45; color: #64748b;">Kostenlos anmelden, du trittst deinem Ortsverband automatisch bei.</div>
+                            </div>
+                        </div>
+                        <div style="display: flex; align-items: flex-start; gap: 16px;">
+                            <div style="flex: 0 0 auto; width: 42px; height: 42px; background: #00337F; color: #ffffff; border-radius: 12px 4px 12px 4px; display: flex; align-items: center; justify-content: center; font-family: 'Barlow Condensed', sans-serif; font-weight: 800; font-size: 21px;">3</div>
+                            <div style="display: flex; flex-direction: column; gap: 3px;">
+                                <div style="font-weight: 700; font-size: 17px; color: #1e293b;">Loslegen</div>
+                                <div style="font-size: 14px; line-height: 1.45; color: #64748b;">Sofort für die Grundausbildung lernen.</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div style="background: rgba(0,51,127,0.04); border: 1px solid rgba(0,51,127,0.10); border-radius: 4px 12px 4px 12px; padding: 14px 16px; font-size: 13px; line-height: 1.5; color: #475569; margin-top: 22px;">
+                        <span style="font-weight: 700; color: #1e293b;">Registrierung ohne Scannen:</span> Auf <span style="font-weight: 700; color: #00337F;">{{ $host }}</span> registrieren und den Code <span style="font-family: 'IBM Plex Mono', monospace; font-weight: 600; color: #00337F;">{{ $invitation->code }}</span> eingeben.
+                    </div>
                 </div>
             </div>
 
-            <div class="benefits">
-                <span class="benefit">Theoriefragen-Training</span>
-                <span class="benefit">Prüfungssimulation</span>
-                <span class="benefit">Fortschritt &amp; Statistiken</span>
-                <span class="benefit">100 % kostenlos</span>
+            <div style="display: flex; gap: 8px; flex-wrap: nowrap; margin-top: 36px;">
+                <div style="font-weight: 600; font-size: 12px; color: #1e293b; border: 1px solid rgba(0,51,127,0.15); border-radius: 9999px; padding: 7px 13px; white-space: nowrap;">Alle offiziellen + optionale Fragen</div>
+                <div style="font-weight: 600; font-size: 12px; color: #1e293b; border: 1px solid rgba(0,51,127,0.15); border-radius: 9999px; padding: 7px 13px; white-space: nowrap;">Prüfungssimulation</div>
+                <div style="font-weight: 600; font-size: 12px; color: #1e293b; border: 1px solid rgba(0,51,127,0.15); border-radius: 9999px; padding: 7px 13px; white-space: nowrap;">Fortschritt &amp; Statistiken</div>
+                <div style="font-weight: 600; font-size: 12px; color: #1e293b; border: 1px solid rgba(0,51,127,0.15); border-radius: 9999px; padding: 7px 13px; white-space: nowrap;">100&nbsp;% kostenlos</div>
             </div>
-        </div>
 
-        <div class="sheet__foot">
-            <div class="foot-url"><span>{{ $host }}</span></div>
-            <div class="foot-note">
-                Ein Angebot für das Technische Hilfswerk.<br>
-                Aufgehängt vom OV {{ $ortsverband->name }}.
+            <div style="margin-top: auto; border-top: 1px solid rgba(0,51,127,0.10); padding-top: 14px; display: flex; align-items: center; justify-content: space-between; gap: 16px;">
+                <div style="font-family: 'IBM Plex Mono', monospace; font-weight: 600; font-size: 12px; letter-spacing: 0.04em; color: #b45309;">{{ $host }}</div>
+                <div style="font-size: 11.5px; color: #64748b; text-align: right;">Ein Lernangebot für Helferinnen und Helfer des THW · Aufgehängt vom {{ $ortsverband->name }}</div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Was

Der druckfertige A4-**Aushang** (Ortsverband → Einladungen → „Aushang (A4-PDF)") wurde 1:1 an das freigegebene Design-System-Layout angepasst.

## Warum

Der bisherige Aushang wich vom Design ab (zentriertes Layout, Gold-Gradienten, blaue Kopf-/Fußbänder). Ziel war eine exakte Übernahme des importierten Designs (`Aushang A4.dc.html`).

## Änderungen

- `resources/views/ortsverband/invitations/aushang.blade.php` komplett durch das Design-Layout ersetzt:
  - 8px THW-Blau Kopfband, Header mit Logo + Mono-Subtitle + „SCANNEN & MITMACHEN"-Pill
  - Barlow-Condensed Headline „Übe die Theorie der Grundausbildung."
  - Asymmetrische QR-Karte mit OV-Name + Code-Pill
  - Drei nummerierte Schritte, „Registrierung ohne Scannen"-Box, vier Tag-Pills, Fußzeile
- Nur die View wurde geändert — Controller-Action `aushang`, Route und der Button bestanden bereits.
- Platzhalter → App-Daten: `$ortsverband->name`, `$invitation->code`, eingebettetes Logo/QR (Data-URI), Domain aus `$host`.

## Für Reviewer

- Fonts (Barlow Condensed / Figtree / IBM Plex Mono) via fonts.bunny.net.
- Druck: `@page { size: A4; margin: 0 }`, Sheet 210×297mm, `print-color-adjust: exact` — im Druckdialog „Ränder: Keine" wählen.
- Kein `npm run build` nötig (nur Inline-Styles, keine neuen Tailwind-Klassen).
- Verifiziert: Blade kompiliert, alle Platzhalter lösen auf, Rendering deckt sich mit dem Design (echter QR-mit-Logo füllt in der App die QR-Box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)