### PR TITLE
🎨: Changelog ohne GitHub-Links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ fetch(url, { cache: 'no-store' });
 - **`CHANGELOG.md`** (Repo-Root, Keep-a-Changelog-Format) wird öffentlich unter `/wiki/changelog` gerendert
 - **`VERSION`**-Datei = Single Source of Truth für das Footer-Badge (`<x-version-badge />` in allen Footern)
 - **Release erstellen:** `php artisan app:release X.Y.Z` verschiebt `[Unreleased]` in einen neuen
-  Versionsabschnitt und aktualisiert VERSION, Vergleichs-Links und composer.json. Danach committen + taggen.
+  Versionsabschnitt und aktualisiert VERSION und composer.json. Danach committen + taggen.
 - **Wiki-Inhalte:** Markdown in `resources/wiki/`, Navigation in `config/wiki.php`
 
 ## Detail-Dokumentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versionierung: [Semantic Versioning](https://semver.org/lang/de/)
 
 ### Intern
 
-- Neuer Artisan-Befehl `php artisan app:release X.Y.Z`: verschiebt die `[Unreleased]`-Einträge in einen neuen Versionsabschnitt und aktualisiert VERSION-Datei, Vergleichs-Links und composer.json in einem Schritt.
+- Neuer Artisan-Befehl `php artisan app:release X.Y.Z`: verschiebt die `[Unreleased]`-Einträge in einen neuen Versionsabschnitt und aktualisiert VERSION-Datei und composer.json in einem Schritt.
 - Changelog-Pflege als fester Bestandteil des Entwicklungs-Workflows in CLAUDE.md/AGENTS.md dokumentiert.
 
 ## [1.0.2] - 2026-04-17
@@ -123,8 +123,3 @@ Erste offizielle Version. Bündelt die bisherige Entwicklungshistorie
 - Alle Cronjobs in Laravel Scheduler migriert (1 CloudPanel-Eintrag genügt)
 
 (~15 sonstige PRs zusammengefasst)
-
-[Unreleased]: https://github.com/niclasreutter/THW-Trainer-App/compare/v1.0.2...HEAD
-[1.0.2]: https://github.com/niclasreutter/THW-Trainer-App/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/niclasreutter/THW-Trainer-App/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/niclasreutter/THW-Trainer-App/commits/main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ fetch(url, { cache: 'no-store' });
 - **`CHANGELOG.md`** (Repo-Root, Keep-a-Changelog-Format) wird öffentlich unter `/wiki/changelog` gerendert
 - **`VERSION`**-Datei = Single Source of Truth für das Footer-Badge (`<x-version-badge />` in allen Footern)
 - **Release erstellen:** `php artisan app:release X.Y.Z` verschiebt `[Unreleased]` in einen neuen
-  Versionsabschnitt und aktualisiert VERSION, Vergleichs-Links und composer.json. Danach committen + taggen.
+  Versionsabschnitt und aktualisiert VERSION und composer.json. Danach committen + taggen.
 - **Wiki-Inhalte:** Markdown in `resources/wiki/`, Navigation in `config/wiki.php`
 
 ## Detail-Dokumentation

--- a/app/Console/Commands/ReleaseCommand.php
+++ b/app/Console/Commands/ReleaseCommand.php
@@ -6,8 +6,8 @@ use Illuminate\Console\Command;
 
 /**
  * Release vorbereiten: verschiebt die Einträge aus "## [Unreleased]" in
- * einen neuen Versionsabschnitt im CHANGELOG.md, aktualisiert die
- * Vergleichs-Links, die VERSION-Datei und composer.json.
+ * einen neuen Versionsabschnitt im CHANGELOG.md und aktualisiert die
+ * VERSION-Datei sowie composer.json.
  *
  * Beispiel: php artisan app:release 1.1.0
  */
@@ -60,11 +60,6 @@ class ReleaseCommand extends Command
             return self::FAILURE;
         }
 
-        // Repo-URL aus vorhandenen Vergleichs-Links ableiten
-        $repoUrl = preg_match('#^\[[^\]]+\]:\s*(https://github\.com/[^/]+/[^/]+)/#m', $changelog, $repoMatch)
-            ? $repoMatch[1]
-            : 'https://github.com/niclasreutter/THW-Trainer-App';
-
         $date = now()->format('Y-m-d');
 
         // Unreleased leeren und neuen Versionsabschnitt direkt darunter einfügen
@@ -76,21 +71,7 @@ class ReleaseCommand extends Command
             strlen($m[0][0])
         );
 
-        // Vergleichs-Links pflegen: [Unreleased] aktualisieren bzw. ergänzen, neue Version einfügen
-        $unreleasedLink = "[Unreleased]: {$repoUrl}/compare/v{$version}...HEAD";
-        $versionLink = $previous !== null
-            ? "[{$version}]: {$repoUrl}/compare/v{$previous}...v{$version}"
-            : "[{$version}]: {$repoUrl}/commits/main";
-
-        if (preg_match('/^\[Unreleased\]:.*$/m', $changelog)) {
-            $changelog = preg_replace('/^\[Unreleased\]:.*$/m', "{$unreleasedLink}\n{$versionLink}", $changelog, 1);
-        } elseif (preg_match('/^\[\d+\.\d+\.\d+\]:.*$/m', $changelog, $firstRef, PREG_OFFSET_CAPTURE)) {
-            $changelog = substr_replace($changelog, "{$unreleasedLink}\n{$versionLink}\n", $firstRef[0][1], 0);
-        } else {
-            $changelog = rtrim($changelog) . "\n\n{$unreleasedLink}\n{$versionLink}\n";
-        }
-
-        file_put_contents($changelogPath, $changelog);
+        file_put_contents($changelogPath, rtrim($changelog) . "\n");
 
         // VERSION-Datei (Quelle für das Footer-Badge)
         file_put_contents(base_path('VERSION'), $version . "\n");


### PR DESCRIPTION
- Linkreferenzen ([Unreleased], [1.0.2], ...) aus CHANGELOG.md entfernt - Versionsüberschriften sind im Wiki jetzt reiner Text
- app:release pflegt keine Vergleichs-Links mehr (vereinfacht)
- Anker-IDs der Versionen bleiben unverändert, Deep-Links funktionieren weiter


Claude-Session: https://claude.ai/code/session_014qHtXor8xCigSwpKTMTi8d