### PR TITLE
🐛: Liga-Teilnahme nur mit Zustimmung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Alle nennenswerten Änderungen an diesem Projekt werden hier dokumentiert.
 
 ## [Unreleased]
 
+### Bugfixes
+
+- **Liga-Teilnahme respektiert Zustimmung**: Nutzer ohne Leaderboard-Einwilligung nehmen nicht mehr am wöchentlichen Liga-Wettbewerb teil. Bisher konnten "unsichtbare" Teilnehmer (ohne Zustimmung) trotzdem Wochenbelohnungen gewinnen sowie auf- und absteigen und verzerrten so das Ranking. Jetzt werden bei der wöchentlichen Verarbeitung nur noch zustimmende Nutzer für Belohnungen, Auf- und Abstieg berücksichtigt.
+
 ## [1.1.0] - 2026-07-17
 
 ### Neue Features

--- a/app/Services/LeagueService.php
+++ b/app/Services/LeagueService.php
@@ -182,7 +182,12 @@ class LeagueService
         $leagueKeys = array_keys(self::LEAGUES);
 
         foreach ($leagueKeys as $league) {
-            $users = User::where('league', $league)
+            // Nur User, die der Leaderboard-Teilnahme zugestimmt haben, nehmen am
+            // Liga-Wettbewerb teil (Ranking, Auf-/Abstieg, Wochenbelohnungen). User
+            // ohne Zustimmung sind zwar in der Liga, "sitzen" die Woche aber aus –
+            // sonst gewinnen unsichtbare Teilnehmer Preise und verzerren das Ranking.
+            $users = User::where('leaderboard_consent', true)
+                ->where('league', $league)
                 ->where('weekly_points', '>', 0)
                 ->orderBy('weekly_points', 'desc')
                 ->orderBy('points', 'desc')

--- a/tests/Feature/LeagueParticipationConsentTest.php
+++ b/tests/Feature/LeagueParticipationConsentTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Models\Lootbox;
+use App\Models\User;
+use App\Services\LeagueService;
+
+test('processWeeklyLeagues vergibt Wochenbelohnungen nur an User mit Zustimmung', function () {
+    // Höchste Punktzahl, aber KEINE Zustimmung -> darf nicht gewinnen
+    $ohneZustimmung = User::factory()->create([
+        'name' => 'Alfred Müller',
+        'leaderboard_consent' => false,
+        'league' => 'diamant',
+        'weekly_points' => 9000,
+    ]);
+
+    $ersterMitZustimmung = User::factory()->create([
+        'name' => 'Hans Peter',
+        'leaderboard_consent' => true,
+        'league' => 'diamant',
+        'weekly_points' => 7000,
+    ]);
+
+    $zweiterMitZustimmung = User::factory()->create([
+        'name' => 'Max Mustermann',
+        'leaderboard_consent' => true,
+        'league' => 'diamant',
+        'weekly_points' => 6000,
+    ]);
+
+    (new LeagueService())->processWeeklyLeagues();
+
+    // Unsichtbarer Teilnehmer erhält trotz höchster Punktzahl KEINE Belohnung
+    expect(Lootbox::where('user_id', $ohneZustimmung->id)->count())->toBe(0);
+
+    // Belohnungen richten sich ausschließlich nach dem Ranking der zustimmenden User
+    expect(Lootbox::where('user_id', $ersterMitZustimmung->id)->where('type', 'gold')->exists())->toBeTrue();
+    expect(Lootbox::where('user_id', $zweiterMitZustimmung->id)->where('type', 'silber')->exists())->toBeTrue();
+});
+
+test('processWeeklyLeagues befördert keine User ohne Zustimmung', function () {
+    // Höchste Punktzahl, aber keine Zustimmung -> darf nicht aufsteigen
+    $ohneZustimmung = User::factory()->create([
+        'name' => 'Alfred Müller',
+        'leaderboard_consent' => false,
+        'league' => 'bronze',
+        'weekly_points' => 9000,
+    ]);
+
+    // Genug zustimmende User, damit ein Aufstieg grundsätzlich möglich wäre
+    User::factory()->create(['leaderboard_consent' => true, 'league' => 'bronze', 'weekly_points' => 4000]);
+    User::factory()->create(['leaderboard_consent' => true, 'league' => 'bronze', 'weekly_points' => 3000]);
+    User::factory()->create(['leaderboard_consent' => true, 'league' => 'bronze', 'weekly_points' => 2000]);
+
+    (new LeagueService())->processWeeklyLeagues();
+
+    // Trotz höchster Punktzahl bleibt der User ohne Zustimmung in seiner Liga
+    expect($ohneZustimmung->fresh()->league)->toBe('bronze');
+
+    // Wochenpunkte werden dennoch für alle zurückgesetzt (kein "Einfrieren" mit altem Score)
+    expect($ohneZustimmung->fresh()->weekly_points)->toBe(0);
+});
+
+test('processWeeklyLeagues befördert zustimmende User weiterhin normal', function () {
+    // Sicherstellen, dass der Consent-Filter den normalen Aufstieg nicht kaputt macht
+    $aufsteiger = User::factory()->create([
+        'leaderboard_consent' => true,
+        'league' => 'bronze',
+        'weekly_points' => 5000,
+    ]);
+    User::factory()->create(['leaderboard_consent' => true, 'league' => 'bronze', 'weekly_points' => 400]);
+    User::factory()->create(['leaderboard_consent' => true, 'league' => 'bronze', 'weekly_points' => 350]);
+
+    (new LeagueService())->processWeeklyLeagues();
+
+    expect($aufsteiger->fresh()->league)->toBe('silber');
+});


### PR DESCRIPTION
https://claude.ai/code/session_01FA7HJX5xDnBNvpG1tSiZyL